### PR TITLE
Failover on false condition

### DIFF
--- a/src/Console/stubs/block.full.stub
+++ b/src/Console/stubs/block.full.stub
@@ -66,6 +66,6 @@ class DummyClass extends Block {
      */
     public function items()
     {
-        return get_field('items') ?? [];
+        return get_field('items') ?: [];
     }
 }

--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -56,6 +56,6 @@ class DummyClass extends Block {
      */
     public function items()
     {
-        return get_field('items') ?? [];
+        return get_field('items') ?: [];
     }
 }


### PR DESCRIPTION
get_field, when it doesn't find a field value, defaults to returning FALSE rather than NULL