### PR TITLE
Standardize the block classes output

### DIFF
--- a/src/BlockClasses
+++ b/src/BlockClasses
@@ -1,0 +1,25 @@
+<?php
+
+namespace Log1x\AcfComposer;
+
+use Illuminate\Support\Str;
+
+trait BlockClasses {
+
+    public function getBlockClasses() {
+        return $this->processBlockClasses();
+    }
+
+    public function processBlockClasses() {
+        $block   = $this->block;
+        $align   = !empty($block->align) ? 'align' . $block->align : '';
+        $title   = $this->getBlockPrefix() . '-' . Str::slug($block->title);
+        $classes = $block->className ?? '';
+
+        return preg_replace('/ {2,}/', ' ', trim($classes . ' ' . $title . ' ' . $align));
+    }
+
+    private function getBlockPrefix() {
+        return $this->blockPrefix ?? 'wp';
+    }
+}

--- a/src/BlockClasses
+++ b/src/BlockClasses
@@ -13,13 +13,9 @@ trait BlockClasses {
     public function processBlockClasses() {
         $block   = $this->block;
         $align   = !empty($block->align) ? 'align' . $block->align : '';
-        $title   = $this->getBlockPrefix() . '-' . Str::slug($block->title);
+        $title   = 'wp-block-' . '-' . Str::slug($block->title);
         $classes = $block->className ?? '';
 
         return preg_replace('/ {2,}/', ' ', trim($classes . ' ' . $title . ' ' . $align));
-    }
-
-    private function getBlockPrefix() {
-        return $this->blockPrefix ?? 'wp';
     }
 }

--- a/src/BlockClasses
+++ b/src/BlockClasses
@@ -13,7 +13,7 @@ trait BlockClasses {
     public function processBlockClasses() {
         $block   = $this->block;
         $align   = !empty($block->align) ? 'align' . $block->align : '';
-        $title   = 'wp-block-' . '-' . Str::slug($block->title);
+        $title   = 'wp-block-' . Str::slug($block->title);
         $classes = $block->className ?? '';
 
         return preg_replace('/ {2,}/', ' ', trim($classes . ' ' . $title . ' ' . $align));


### PR DESCRIPTION
Definitely not perfect, but I wanted the idea out there at least. This would allow people to add `use BlockClasses;` in their Block definitions to have an easy way to grab the info. Currently you have to also add to the `with()` returned array `'block_classes' => $this->getBlockClasses(),` or something like it to pass it to the view, but I would prefer that to be injected by the trait, I just couldn't figure out how to do it.

They can also add a `protected $blockPrefix = 'company';` to the class file to override the default `wp-block-slug` to something like `company-block-slug.`

Sidenote: I'm still moving away from ACF but I do have to finish this, and maybe even one more project before Christmas first =P