### PR TITLE
Add the rest of the acf add option page fields

### DIFF
--- a/src/Console/stubs/options.full.stub
+++ b/src/Console/stubs/options.full.stub
@@ -15,6 +15,13 @@ class DummyClass extends Field
     public $name = 'DummyClass';
 
     /**
+     * The option page menu slug.
+     *
+     * @var string
+     */
+    public $slug = 'DummySlug';
+
+    /**
      * The option page document title.
      *
      * @var string
@@ -36,6 +43,34 @@ class DummyClass extends Field
     public $position = PHP_INT_MAX;
 
     /**
+     * The slug of another admin page to be used as a parent.
+     *
+     * @var string
+     */
+    public $parent = null;
+
+    /**
+     * The option page menu icon.
+     *
+     * @var string
+     */
+    public $icon = null;
+
+    /**
+     * Redirect to the first child page if one exists.
+     *
+     * @var boolean
+     */
+    public $redirect = true;
+
+    /**
+     * The post ID to save and load values from.
+     *
+     * @var string|int
+     */
+    public $post = 'options';
+
+    /**
      * The option page autoload setting.
      *
      * @var bool
@@ -43,40 +78,7 @@ class DummyClass extends Field
     public $autoload = true;
 
     /**
-     * The icon used in the menu.
-     *
-     * @var string
-     */
-    public $icon = null;
-
-    /**
-     * Whether to redirect to child pages.
-     *
-     * @var boolean
-     */
-    public $redirect = true;
-
-    /**
-     * The parent of this page, if any.
-     *
-     * @var string
-     */
-    public $parent = null;
-
-    /**
-     * Where to save this data.
-     *
-     * Accepts strings (i.e. 'user_2') or numbers (i.e. 123).
-     *
-     * @link https://www.advancedcustomfields.com/resources/get_field/
-     * @var string|int
-     */
-    public $post = 'options';
-
-    /**
-     * Text displayed on the option page submit button.
-     *
-     * Implemented as a function to support localization.
+     * Localized text displayed on the submit button.
      *
      * @return string
      */
@@ -86,15 +88,13 @@ class DummyClass extends Field
     }
 
     /**
-     * Text displayed above form after submission.
-     *
-     * Implemented as a function to support localization.
+     * Localized text displayed after form submission.
      *
      * @return string
      */
     public function updatedMessage()
     {
-        return __("DummyClass Updated", 'acf');
+        return __('Options Updated', 'acf');
     }
 
     /**

--- a/src/Console/stubs/options.full.stub
+++ b/src/Console/stubs/options.full.stub
@@ -43,6 +43,61 @@ class DummyClass extends Field
     public $autoload = true;
 
     /**
+     * The icon used in the menu.
+     *
+     * @var string
+     */
+    public $icon = null;
+
+    /**
+     * Whether to redirect to child pages.
+     *
+     * @var boolean
+     */
+    public $redirect = true;
+
+    /**
+     * The parent of this page, if any.
+     *
+     * @var string
+     */
+    public $parent = null;
+
+    /**
+     * Where to save this data.
+     *
+     * Accepts strings (i.e. 'user_2') or numbers (i.e. 123).
+     *
+     * @link https://www.advancedcustomfields.com/resources/get_field/
+     * @var string|int
+     */
+    public $post = 'options';
+
+    /**
+     * Text displayed on the option page submit button.
+     *
+     * Implemented as a function to support localization.
+     *
+     * @return string
+     */
+    public function updateButton()
+    {
+        return __('Update', 'acf');
+    }
+
+    /**
+     * Text displayed above form after submission.
+     *
+     * Implemented as a function to support localization.
+     *
+     * @return string
+     */
+    public function updatedMessage()
+    {
+        return __("DummyClass Updated", 'acf');
+    }
+
+    /**
      * The option page field group.
      *
      * @return array

--- a/src/Options.php
+++ b/src/Options.php
@@ -43,6 +43,34 @@ abstract class Options extends Composer
     public $position = PHP_INT_MAX;
 
     /**
+     * The slug of another admin page to be used as a parent.
+     *
+     * @var string
+     */
+    public $parent = null;
+
+    /**
+     * The option page menu icon.
+     *
+     * @var string
+     */
+    public $icon = null;
+
+    /**
+     * Redirect to the first child page if one exists.
+     *
+     * @var boolean
+     */
+    public $redirect = true;
+
+    /**
+     * The post ID to save and load values from.
+     *
+     * @var string|int
+     */
+    public $post = 'options';
+
+    /**
      * The option page autoload setting.
      *
      * @var bool
@@ -50,40 +78,7 @@ abstract class Options extends Composer
     public $autoload = true;
 
     /**
-     * The icon used in the menu.
-     *
-     * @var string
-     */
-    public $icon = null;
-
-    /**
-     * Whether to redirect to child pages.
-     *
-     * @var boolean
-     */
-    public $redirect = true;
-
-    /**
-     * The parent of this page, if any.
-     *
-     * @var string
-     */
-    public $parent = null;
-
-    /**
-     * Where to save this data.
-     *
-     * Accepts strings (i.e. 'user_2') or numbers (i.e. 123).
-     *
-     * @link https://www.advancedcustomfields.com/resources/get_field/
-     * @var string|int
-     */
-    public $post = 'options';
-
-    /**
-     * Text displayed on the option page submit button.
-     *
-     * Implemented as a function to support localization.
+     * Localized text displayed on the submit button.
      *
      * @return string
      */
@@ -93,15 +88,13 @@ abstract class Options extends Composer
     }
 
     /**
-     * Text displayed above form after submission.
-     *
-     * Implemented as a function to support localization.
+     * Localized text displayed after form submission.
      *
      * @return string
      */
     public function updatedMessage()
     {
-        return __("Options Updated", 'acf');
+        return __('Options Updated', 'acf');
     }
 
     /**
@@ -131,11 +124,11 @@ abstract class Options extends Composer
                 'page_title' => $this->title,
                 'capability' => $this->capability,
                 'position' => $this->position,
-                'autoload' => $this->autoload,
-                'icon_url' => $this->icon,
                 'parent_slug' => $this->parent,
+                'icon_url' => $this->icon,
                 'redirect' => $this->redirect,
                 'post_id' => $this->post,
+                'autoload' => $this->autoload,
                 'update_button' => $this->updateButton(),
                 'updated_message' => $this->updatedMessage()
             ]);

--- a/src/Options.php
+++ b/src/Options.php
@@ -50,6 +50,61 @@ abstract class Options extends Composer
     public $autoload = true;
 
     /**
+     * The icon used in the menu.
+     *
+     * @var string
+     */
+    public $icon = null;
+
+    /**
+     * Whether to redirect to child pages.
+     *
+     * @var boolean
+     */
+    public $redirect = true;
+
+    /**
+     * The parent of this page, if any.
+     *
+     * @var string
+     */
+    public $parent = null;
+
+    /**
+     * Where to save this data.
+     *
+     * Accepts strings (i.e. 'user_2') or numbers (i.e. 123).
+     *
+     * @link https://www.advancedcustomfields.com/resources/get_field/
+     * @var string|int
+     */
+    public $post = 'options';
+
+    /**
+     * Text displayed on the option page submit button.
+     *
+     * Implemented as a function to support localization.
+     *
+     * @return string
+     */
+    public function updateButton()
+    {
+        return __('Update', 'acf');
+    }
+
+    /**
+     * Text displayed above form after submission.
+     *
+     * Implemented as a function to support localization.
+     *
+     * @return string
+     */
+    public function updatedMessage()
+    {
+        return __("Options Updated", 'acf');
+    }
+
+    /**
      * Compose and register the defined field groups with ACF.
      *
      * @param  callback $callback
@@ -76,7 +131,13 @@ abstract class Options extends Composer
                 'page_title' => $this->title,
                 'capability' => $this->capability,
                 'position' => $this->position,
-                'autoload' => $this->autoload
+                'autoload' => $this->autoload,
+                'icon_url' => $this->icon,
+                'parent_slug' => $this->parent,
+                'redirect' => $this->redirect,
+                'post_id' => $this->post,
+                'update_button' => $this->updateButton(),
+                'updated_message' => $this->updatedMessage()
             ]);
 
             if (! Arr::has($this->fields, 'location.0.0')) {


### PR DESCRIPTION
This adds the rest of the option page registration options supported by `acf_add_options_page()`