### PR TITLE
Require "doctrine/inflector":"^1.4"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   },
   "require": {
     "php": ">=7.2.5",
+    "doctrine/inflector": "^1.4",
     "stoutlogic/acf-builder": "^1.9"
   },
   "require-dev": {


### PR DESCRIPTION
Since `stoutlogic/acf-builder` requires `"doctrine/inflector":"^1.1"`, we need to make sure there is a compatible version required. #14