### PR TITLE
Support key for <InnerBlocks /> changed

### DIFF
--- a/src/Console/stubs/block.innerblocks.stub
+++ b/src/Console/stubs/block.innerblocks.stub
@@ -41,7 +41,7 @@ class DummyClass extends Block
      * @var array
      */
     public $supports = [
-        '__experimental_jsx' => true,
+        'jsx' => true,
         'mode' => false,
     ];
 


### PR DESCRIPTION
[From ACF Pro 5.9 RC 1 onward](https://www.advancedcustomfields.com/blog/acf-pro-5-9-rc1/) the key for `<InnerBlocks />` support changed from `__experimental_jsx` to simply `jsx`.