### PR TITLE
Add support for 'align_text' and 'align_content'

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -124,6 +124,20 @@ abstract class Block extends Composer implements BlockContract
     public $align = '';
 
     /**
+     * The block text alignment class.
+     *
+     * @var string
+     */
+    public $align_text = '';
+
+    /**
+     * The block text alignment class.
+     *
+     * @var string
+     */
+    public $align_content = '';
+
+    /**
      * Features supported by the block.
      *
      * @var array
@@ -168,6 +182,13 @@ abstract class Block extends Composer implements BlockContract
             ]);
         }
 
+        // The matrix isn't available on WP > 5.5
+        if (Arr::has($this->supports, 'align_content') && version_compare('5.5', get_bloginfo('version'), '>')) {
+            if (! is_bool($this->supports['align_content'])) {
+                $this->supports['align_content'] = true;
+            }
+        }
+
         $this->register(function () {
             acf_register_block([
                 'name' => $this->slug,
@@ -179,6 +200,8 @@ abstract class Block extends Composer implements BlockContract
                 'post_types' => $this->post_types,
                 'mode' => $this->mode,
                 'align' => $this->align,
+                'align_text' => $this->align_text ?? $this->align,
+                'align_content' => $this->align_content,
                 'supports' => $this->supports,
                 'enqueue_assets' => function () {
                     return $this->enqueue();


### PR DESCRIPTION
As ACF Pro 5.9 introduces support for text / content alignment for blocks (https://github.com/AdvancedCustomFields/acf/issues/335), this adds the needed attributes. Also this adds a check to prevent a bug when set up `align_conten` to use the new matrix control which is available in WordPress 5.5 (https://github.com/AdvancedCustomFields/acf/issues/352)