### PR TITLE
Add example/previews support

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -96,8 +96,8 @@ abstract class Block extends Composer implements BlockContract
     public $icon = '';
 
     /**
-     * An array of dummy data for previews
-     *s
+     * The block preview example data.
+     *
      * @var array
      */
     public $example = [];

--- a/src/Block.php
+++ b/src/Block.php
@@ -96,6 +96,13 @@ abstract class Block extends Composer implements BlockContract
     public $icon = '';
 
     /**
+     * An array of dummy data for previews
+     *s
+     * @var array
+     */
+    public $example = [];
+
+    /**
      * An array of keywords the block will be found under.
      *
      * @var array
@@ -203,6 +210,12 @@ abstract class Block extends Composer implements BlockContract
                 'align_text' => $this->align_text ?? $this->align,
                 'align_content' => $this->align_content,
                 'supports' => $this->supports,
+                'example' => [
+                    'attributes' => [
+                        'mode' => 'preview',
+                        'data' => $this->example,
+                    ]
+                ],
                 'enqueue_assets' => function () {
                     return $this->enqueue();
                 },

--- a/src/Console/stubs/block.full.stub
+++ b/src/Console/stubs/block.full.stub
@@ -36,6 +36,19 @@ class DummyClass extends Block
     public $icon = 'star-half';
 
     /**
+     * An array of dummy data for previews
+     *
+     * @var array
+     */
+    public $example = [
+        'items'   => [
+            ['item' => 'Item one'],
+            ['item' => 'Item two'],
+            ['item' => 'Item three']
+        ],
+    ];
+
+    /**
      * The block keywords.
      *
      * @var array

--- a/src/Console/stubs/block.innerblocks.stub
+++ b/src/Console/stubs/block.innerblocks.stub
@@ -36,6 +36,19 @@ class DummyClass extends Block
     public $icon = 'star-half';
 
     /**
+     * An array of dummy data for previews
+     *
+     * @var array
+     */
+    public $example = [
+        'items'   => [
+            ['item' => 'Item one'],
+            ['item' => 'Item two'],
+            ['item' => 'Item three']
+        ],
+    ];
+
+    /**
      * The block features.
      *
      * @var array


### PR DESCRIPTION
**Summary**
Add example/preview support as per - https://www.advancedcustomfields.com/resources/acf_register_block_type/

**Preview**

![acf-blocks-example-setting](https://user-images.githubusercontent.com/1690006/87541458-32a21380-c699-11ea-9603-8e7b934284f8.png)

**Example Block - Before**

<img width="722" alt="Screenshot 2020-07-15 at 12 42 55" src="https://user-images.githubusercontent.com/1690006/87541530-4baac480-c699-11ea-97db-e4095462c455.png">


**Example Block - After**

<img width="715" alt="Screenshot 2020-07-15 at 12 43 15" src="https://user-images.githubusercontent.com/1690006/87541537-4f3e4b80-c699-11ea-8622-0c436d318fe9.png">
