### PR TITLE
feat: :sparkles: Add ability to override the blocks view (name)

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -19,13 +19,6 @@ abstract class Block extends Composer implements BlockContract
     public $block;
 
     /**
-     * The block view name.
-     *
-     * @var string
-     */
-    protected $viewName;
-
-    /**
      * The block content.
      *
      * @var string
@@ -80,6 +73,13 @@ abstract class Block extends Composer implements BlockContract
      * @var string
      */
     public $slug = '';
+
+    /**
+     * The block view.
+     *
+     * @var string
+     */
+    public $view;
 
     /**
      * The block description.
@@ -184,6 +184,10 @@ abstract class Block extends Composer implements BlockContract
             $this->slug = Str::slug(Str::kebab($this->name));
         }
 
+        if (empty($this->view)) {
+            $this->view = Str::start($this->slug, 'blocks.');
+        }
+
         if (empty($this->namespace)) {
             $this->namespace = Str::start($this->slug, $this->prefix);
         }
@@ -268,24 +272,6 @@ abstract class Block extends Composer implements BlockContract
             'classes' => $this->block->className ?? false,
         ])->filter()->implode(' ');
 
-        return $this->view(
-            $this->guessViewName($this->viewName ?: $this->slug),
-            ['block' => $this]
-        );
-    }
-
-    /**
-     * Guess the view name.
-     *
-     * @param  string  $name
-     * @return string
-     */
-    public function guessViewName($name)
-    {
-        if (Str::contains($name, '.')) {
-            return $name;
-        }
-
-        return Str::finish('blocks.', $name);
+        return $this->view($this->view, ['block' => $this]);
     }
 }

--- a/src/Block.php
+++ b/src/Block.php
@@ -19,6 +19,13 @@ abstract class Block extends Composer implements BlockContract
     public $block;
 
     /**
+     * The block view name.
+     *
+     * @var string
+     */
+    protected $viewName;
+
+    /**
      * The block content.
      *
      * @var string
@@ -233,7 +240,7 @@ abstract class Block extends Composer implements BlockContract
      * @param  string $content
      * @param  bool $preview
      * @param  int $post_id
-     * @return void
+     * @return string
      */
     public function render($block, $content = '', $preview = false, $post_id = 0)
     {
@@ -262,8 +269,23 @@ abstract class Block extends Composer implements BlockContract
         ])->filter()->implode(' ');
 
         return $this->view(
-            Str::finish('blocks.', $this->slug),
+            $this->guessViewName($this->viewName ?: $this->slug),
             ['block' => $this]
         );
+    }
+
+    /**
+     * Guess the view name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public function guessViewName($name)
+    {
+        if (Str::contains($name, '.')) {
+            return $name;
+        }
+
+        return Str::finish('blocks.', $name);
     }
 }


### PR DESCRIPTION

Currently the view file of a Block is based on it's slug. To be able to use own Block Composer for multiple variants, this adds the ability to specify / overwrite the path to the view.