### PR TITLE
Adds editor preview block

### DIFF
--- a/src/Concerns/InteractsWithBlade.php
+++ b/src/Concerns/InteractsWithBlade.php
@@ -15,14 +15,12 @@ trait InteractsWithBlade
      */
     public function view($view, $with = [])
     {
-        if ($this->preview === true) {
-            $preview = str_replace('blocks.', 'blocks.preview-', $view);
-            if (view()->exists($preview)) {
-                $view = $preview;
-            }
-        }
-        if (!view()->exists($view)) {
-            return;
+        if (
+            isset($this->block) &&
+            ! empty($this->preview) &&
+            view()->exists(Str::start($view, 'preview-'))
+        ) {
+            $view = Str::start($view, 'preview-');
         }
 
         return view($view, $with, $this->with())->render();

--- a/src/Concerns/InteractsWithBlade.php
+++ b/src/Concerns/InteractsWithBlade.php
@@ -15,7 +15,13 @@ trait InteractsWithBlade
      */
     public function view($view, $with = [])
     {
-        if (! view()->exists($view)) {
+        if ($this->preview === true) {
+            $preview = str_replace('blocks.', 'blocks.preview-', $view);
+            if (view()->exists($preview)) {
+                $view = $preview;
+            }
+        }
+        if (!view()->exists($view)) {
             return;
         }
 


### PR DESCRIPTION
A block with the “preview-“ prefix will be used in the block editor instead of the standard block template if available. My front facing block uses Vue so I wanted to simplify the display in the block editor. Got the idea from block-lab.