### PR TITLE
feat: Use block slug for base class name

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -267,7 +267,7 @@ abstract class Block extends Composer implements BlockContract
 
         $this->classes = collect([
             'slug' => Str::start(
-                Str::slug($this->block->title),
+                Str::slug($this->slug),
                 'wp-block-'
             ),
             'align' => ! empty($this->block->align) ?


### PR DESCRIPTION
The base class for a block is determined by slugging the block title. For a block with title `Employees` this will result in a base class of `.wp-block-employees` which is fine.

When one localizes the blocks name in the constructor this may lead to unexpected results:

```php
public function __construct(Application $app)
{
    parent::__construct($app);

    $this->name = __('Employees', 'sage');
    $this->slug = 'employees';
}
```

This may translate to a block name of `Mitarbeiter` in German, which will result in a localized base class of `.wp-block-mitarbeiter` so that classes differ when switching languages. 

I propose to use the slug for determining the base class instead.