### PR TITLE
Fix treating some options as a layout field

### DIFF
--- a/src/Composer.php
+++ b/src/Composer.php
@@ -99,8 +99,8 @@ abstract class Composer implements FieldContract
         return collect($fields)->map(
             function ($value, $key) {
                 if (
-                    !in_array($key, $this->keys) ||
-                    (Str::is($key, 'type') && !$this->defaults->has($value))
+                    ! in_array($key, $this->keys) ||
+                    (Str::is($key, 'type') && ! $this->defaults->has($value))
                 ) {
                     return $value;
                 }
@@ -111,7 +111,8 @@ abstract class Composer implements FieldContract
                             if (in_array($key, $this->keys)) {
                                 return $this->build($field);
                             }
-                            if ((Str::is($key, 'type') && $this->defaults->has($value))) {
+                            
+                            if (Str::is($key, 'type') && $this->defaults->has($value)) {
                                 $field = array_merge($this->defaults->get($field['type'], []), $field);
                             }
                         }

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -99,7 +99,7 @@ abstract class Composer implements FieldContract
         return collect($fields)->map(
             function ($value, $key) {
                 if (
-                    ! Str::contains($key, $this->keys) ||
+                    !in_array($key, $this->keys) ||
                     (Str::is($key, 'type') && !$this->defaults->has($value))
                 ) {
                     return $value;
@@ -108,7 +108,7 @@ abstract class Composer implements FieldContract
                 return array_map(
                     function ($field) {
                         foreach ($field as $key => $value) {
-                            if (Str::contains($key, $this->keys)) {
+                            if (in_array($key, $this->keys)) {
                                 return $this->build($field);
                             }
                             if ((Str::is($key, 'type') && $this->defaults->has($value))) {


### PR DESCRIPTION
Current condition treats any option that include any of the following words fields, sub_fields, or layouts as a field group.
Therefore, options such as `'acfe_flexible_layouts_thumbnails' => 1,` weren't being passed to the acf-builder properly.

see https://github.com/Log1x/acf-composer/issues/64