### PR TITLE
Add anchor/id attr support to Block stubs

### DIFF
--- a/src/Console/stubs/block.construct.stub
+++ b/src/Console/stubs/block.construct.stub
@@ -28,6 +28,7 @@ class DummyClass extends Block
             'align' => true,
             'align_text' => false,
             'align_content' => false,
+            'anchor' => false,
             'mode' => false,
             'multiple' => true,
             'jsx' => true,

--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -93,6 +93,7 @@ class DummyClass extends Block
         'align' => true,
         'align_text' => false,
         'align_content' => false,
+        'anchor' => false,
         'mode' => false,
         'multiple' => true,
         'jsx' => true,


### PR DESCRIPTION
Add undocumented acf anchor support feature - ref: https://support.advancedcustomfields.com/forums/topic/anchor-in-wp-blocks/
