### PR TITLE
feat(block): ✨ Add support to get the active block style

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -166,6 +166,13 @@ abstract class Block extends Composer implements BlockContract
     public $styles = [];
 
     /**
+     * The block active style.
+     *
+     * @var string
+     */
+    public $style;
+
+    /**
      * The block preview example data.
      *
      * @var array
@@ -180,6 +187,20 @@ abstract class Block extends Composer implements BlockContract
     public function enqueue()
     {
         //
+    }
+
+    /**
+     * Returns the active block style based on the block CSS classes.
+     * If none is found, it returns the default style set in $styles.
+     *
+     * @return string|null
+     */
+    public function getStyle()
+    {
+        return Str::of($this->block->className ?? null)
+            ->matchAll('/is-style-(\S+)/')
+            ->get(0) ??
+            Arr::get(collect($this->block->styles)->firstWhere('isDefault'), 'name');
     }
 
     /**
@@ -289,6 +310,8 @@ abstract class Block extends Composer implements BlockContract
                 false,
             'classes' => $this->block->className ?? false,
         ])->filter()->implode(' ');
+
+        $this->style = $this->getStyle();
 
         return $this->view($this->view, ['block' => $this]);
     }

--- a/src/Block.php
+++ b/src/Block.php
@@ -214,7 +214,7 @@ abstract class Block extends Composer implements BlockContract
             ]);
         }
 
-        // The matrix isn't available on WP > 5.5
+        // The matrix isn't available on WP < 5.5
         if (Arr::has($this->supports, 'align_content') && version_compare('5.5', get_bloginfo('version'), '>')) {
             if (! is_bool($this->supports['align_content'])) {
                 $this->supports['align_content'] = true;


### PR DESCRIPTION
After a dirty PR (#83) this PR adds support to get the active block style based on the CSS classes.

It uses the CSS classes set for the block and matches the patter `is-style-{style}`. If none is found in the class names the method `getStyle()` falls back to the default style defined in the $styles property.

This should make it possible to alter the block / component markup based on the active style.