### PR TITLE
feat(block): :sparkles: Add support for full-height

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -287,6 +287,10 @@ abstract class Block extends Composer implements BlockContract
             'align_content' => ! empty($this->supports['align_content']) ?
                 Str::start($this->block->align_content, 'is-position-') :
                 false,
+            'full_height' => ! empty($this->supports['full_height'])
+                && ! empty($this->block->full_height) ?
+                'full-height' :
+                false,
             'classes' => $this->block->className ?? false,
         ])->filter()->implode(' ');
 

--- a/src/Console/stubs/block.construct.stub
+++ b/src/Console/stubs/block.construct.stub
@@ -103,6 +103,7 @@ class DummyClass extends Block
             'align' => true,
             'align_text' => false,
             'align_content' => false,
+            'full_height' => false,
             'anchor' => false,
             'mode' => false,
             'multiple' => true,

--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -93,6 +93,7 @@ class DummyClass extends Block
         'align' => true,
         'align_text' => false,
         'align_content' => false,
+        'full_height' => false,
         'anchor' => false,
         'mode' => false,
         'multiple' => true,


### PR DESCRIPTION
In ACF 5.10 there is now support for the Block Editor’s full height alignment setting when registering a new block.