### PR TITLE
Sort blocks by name

### DIFF
--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -90,7 +90,7 @@ class AcfComposer
             $namespace = $this->app->getNamespace();
         }
 
-        foreach ((new Finder())->in($paths->toArray())->files() as $file) {
+        foreach ((new Finder())->in($paths->toArray())->files()->sortByName() as $file) {
             $composer = $namespace . str_replace(
                 ['/', '.php'],
                 ['\\', ''],


### PR DESCRIPTION
This is a simple modification that will sort the created blocks by name.
In my case, I've been using a custom block category and by default from what I've seen the blocks are ordered by the date, they have been created. Which looks a bit messy on the blocks list.