### PR TITLE
Prevent double fields() call fixes #111

### DIFF
--- a/src/Partial.php
+++ b/src/Partial.php
@@ -4,14 +4,6 @@ namespace Log1x\AcfComposer;
 
 abstract class Partial extends Composer
 {
-
-    /**
-     * The field groups.
-     *
-     * @var \StoutLogic\AcfBuilder\FieldsBuilder|array
-     */
-    protected $fields;
-
     /**
      * Compose and register the defined field groups with ACF.
      *
@@ -19,12 +11,12 @@ abstract class Partial extends Composer
      */
     public function compose()
     {
-        $this->fields = $this->fields();
+        $fields = $this->fields();
 
-        if (empty($this->fields)) {
+        if (empty($fields)) {
             return;
         }
 
-        return $this->fields;
+        return $fields;
     }
 }

--- a/src/Partial.php
+++ b/src/Partial.php
@@ -4,6 +4,14 @@ namespace Log1x\AcfComposer;
 
 abstract class Partial extends Composer
 {
+
+    /**
+     * The field groups.
+     *
+     * @var \StoutLogic\AcfBuilder\FieldsBuilder|array
+     */
+    protected $fields;
+
     /**
      * Compose and register the defined field groups with ACF.
      *
@@ -11,10 +19,12 @@ abstract class Partial extends Composer
      */
     public function compose()
     {
-        if (empty($this->fields())) {
+        $this->fields = $this->fields();
+
+        if (empty($this->fields)) {
             return;
         }
 
-        return $this->fields();
+        return $this->fields;
     }
 }


### PR DESCRIPTION
This PR prevents the double calls to `$this->fields()` in [Partial](https://github.com/Log1x/acf-composer/blob/master/src/Partial.php).