### PR TITLE
Fix subdirectory fully-qualified class name resolution

### DIFF
--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -92,14 +92,14 @@ class AcfComposer
 
         foreach ((new Finder())->in($paths->toArray())->files()->sortByName() as $file) {
             $composer = $namespace . str_replace(
-                    ['/', '.php'],
-                    ['\\', ''],
-                    Str::replace(
-                        $path . DIRECTORY_SEPARATOR,
-                        '',
-                        $file->getPathname(),
-                    ),
-                );
+                ['/', '.php'],
+                ['\\', ''],
+                Str::replace(
+                    $path . DIRECTORY_SEPARATOR,
+                    '',
+                    $file->getPathname(),
+                ),
+            );
 
             if (
                 ! is_subclass_of($composer, Composer::class) ||

--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -92,11 +92,11 @@ class AcfComposer
 
         foreach ((new Finder())->in($paths->toArray())->files()->sortByName() as $file) {
             $composer = $namespace . str_replace(
-                    [ '/', '.php' ],
-                    [ '\\', '' ],
+                    ['/', '.php'],
+                    ['\\', ''],
                     Str::replace(
                         $path . DIRECTORY_SEPARATOR,
-                        "",
+                        '',
                         $file->getPathname(),
                     ),
                 );

--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -92,13 +92,14 @@ class AcfComposer
 
         foreach ((new Finder())->in($paths->toArray())->files()->sortByName() as $file) {
             $composer = $namespace . str_replace(
-                ['/', '.php'],
-                ['\\', ''],
-                Str::after(
-                    $file->getPathname(),
-                    Str::beforeLast($file->getPath(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
-                )
-            );
+                    [ '/', '.php' ],
+                    [ '\\', '' ],
+                    Str::replace(
+                        $path . DIRECTORY_SEPARATOR,
+                        "",
+                        $file->getPathname(),
+                    ),
+                );
 
             if (
                 ! is_subclass_of($composer, Composer::class) ||


### PR DESCRIPTION
Suggested fix for #113 

Works out the class name by removing the registered path from the full pathname, which provides a relative directory path. 

For example:
`/home/jarrod/theme/wp-content/themes/mytheme/app/Blocks/Typography/Heading.php` becomes `Blocks/Typography/Heading.php` after removing the registered path (`/home/jarrod/theme/wp-content/themes/mytheme/app/`).

The remainder of the path is then used to calculate the fully qualified class name, as it does currently.