### PR TITLE
Add option to toggle option page visibility

### DIFF
--- a/src/Console/stubs/options.full.stub
+++ b/src/Console/stubs/options.full.stub
@@ -47,7 +47,7 @@ class DummyClass extends Field
      *
      * @var boolean
      */
-    public $show_in_menu = true;
+    public $menu = true;
 
     /**
      * The slug of another admin page to be used as a parent.

--- a/src/Console/stubs/options.full.stub
+++ b/src/Console/stubs/options.full.stub
@@ -43,6 +43,13 @@ class DummyClass extends Field
     public $position = PHP_INT_MAX;
 
     /**
+     * The option page visibility in the menu admin menu.
+     *
+     * @var boolean
+     */
+    public $show_in_menu = true;
+
+    /**
      * The slug of another admin page to be used as a parent.
      *
      * @var string

--- a/src/Console/stubs/options.full.stub
+++ b/src/Console/stubs/options.full.stub
@@ -43,7 +43,7 @@ class DummyClass extends Field
     public $position = PHP_INT_MAX;
 
     /**
-     * The option page visibility in the menu admin menu.
+     * The option page visibility in the admin menu.
      *
      * @var boolean
      */

--- a/src/Options.php
+++ b/src/Options.php
@@ -132,7 +132,7 @@ abstract class Options extends Composer
         }
 
         $this->register(function () {
-            if (! $this->show_in_menu) {
+            if (! $this->menu) {
                 return;
             }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -43,6 +43,13 @@ abstract class Options extends Composer
     public $position = PHP_INT_MAX;
 
     /**
+     * The option page visibility in the menu admin menu.
+     *
+     * @var boolean
+     */
+    public $show_in_menu = true;
+
+    /**
      * The slug of another admin page to be used as a parent.
      *
      * @var string
@@ -125,20 +132,22 @@ abstract class Options extends Composer
         }
 
         $this->register(function () {
-            acf_add_options_page([
-                'menu_title' => $this->name,
-                'menu_slug' => $this->slug,
-                'page_title' => $this->title,
-                'capability' => $this->capability,
-                'position' => $this->position,
-                'parent_slug' => $this->parent,
-                'icon_url' => $this->icon,
-                'redirect' => $this->redirect,
-                'post_id' => $this->post,
-                'autoload' => $this->autoload,
-                'update_button' => $this->updateButton(),
-                'updated_message' => $this->updatedMessage()
-            ]);
+            if ($this->show_in_menu) {
+                acf_add_options_page([
+                    'menu_title' => $this->name,
+                    'menu_slug' => $this->slug,
+                    'page_title' => $this->title,
+                    'capability' => $this->capability,
+                    'position' => $this->position,
+                    'parent_slug' => $this->parent,
+                    'icon_url' => $this->icon,
+                    'redirect' => $this->redirect,
+                    'post_id' => $this->post,
+                    'autoload' => $this->autoload,
+                    'update_button' => $this->updateButton(),
+                    'updated_message' => $this->updatedMessage()
+                ]);
+            }
         });
 
         return $this;

--- a/src/Options.php
+++ b/src/Options.php
@@ -43,7 +43,7 @@ abstract class Options extends Composer
     public $position = PHP_INT_MAX;
 
     /**
-     * The option page visibility in the menu admin menu.
+     * The option page visibility in the admin menu.
      *
      * @var boolean
      */
@@ -132,22 +132,24 @@ abstract class Options extends Composer
         }
 
         $this->register(function () {
-            if ($this->show_in_menu) {
-                acf_add_options_page([
-                    'menu_title' => $this->name,
-                    'menu_slug' => $this->slug,
-                    'page_title' => $this->title,
-                    'capability' => $this->capability,
-                    'position' => $this->position,
-                    'parent_slug' => $this->parent,
-                    'icon_url' => $this->icon,
-                    'redirect' => $this->redirect,
-                    'post_id' => $this->post,
-                    'autoload' => $this->autoload,
-                    'update_button' => $this->updateButton(),
-                    'updated_message' => $this->updatedMessage()
-                ]);
+            if (! $this->show_in_menu) {
+                return;
             }
+
+            acf_add_options_page([
+                'menu_title' => $this->name,
+                'menu_slug' => $this->slug,
+                'page_title' => $this->title,
+                'capability' => $this->capability,
+                'position' => $this->position,
+                'parent_slug' => $this->parent,
+                'icon_url' => $this->icon,
+                'redirect' => $this->redirect,
+                'post_id' => $this->post,
+                'autoload' => $this->autoload,
+                'update_button' => $this->updateButton(),
+                'updated_message' => $this->updatedMessage()
+            ]);
         });
 
         return $this;

--- a/src/Options.php
+++ b/src/Options.php
@@ -47,7 +47,7 @@ abstract class Options extends Composer
      *
      * @var boolean
      */
-    public $show_in_menu = true;
+    public $menu = true;
 
     /**
      * The slug of another admin page to be used as a parent.


### PR DESCRIPTION
There are situations in which it is desirable to register an option
page's fields but omit the page from the admin menu. In these
situations, a developer can set `show_in_menu` to `false`, which
causes the instantiated options object to skip the call it would
otherwise make to `acf_add_options_page`.

This feature does not affect the existing expected functionality of
the plugin, as `show_in_menu` is by default set to `true`.