### PR TITLE
fix: Replace `Str::remove()` with `str_replace()` for Acorn 1.x compatibility

### DIFF
--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -88,8 +88,9 @@ class AcfComposer
         }
 
         foreach ((new Finder())->in($paths->toArray())->files()->sortByName() as $file) {
-            $relativePath = Str::remove(
+            $relativePath = str_replace(
                 $this->app->path() . DIRECTORY_SEPARATOR,
+                '',
                 $file->getPathname()
             );
 


### PR DESCRIPTION
Ref: https://github.com/roots/acorn/pull/244