### PR TITLE
Change `$example` conditional

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -266,7 +266,7 @@ abstract class Block extends Composer implements BlockContract
                 },
             ];
 
-            if (! empty($this->example)) {
+            if ($this->example !== false) {
                 $settings = Arr::add($settings, 'example', [
                     'attributes' => [
                         'mode' => 'preview',


### PR DESCRIPTION
## Change log

### Enhancements

- chore(block): Change `$example` conditional to explicitly require `false` to disable block preview