### PR TITLE
Change the order in which the fields are merged

### DIFF
--- a/src/Composer.php
+++ b/src/Composer.php
@@ -61,7 +61,7 @@ abstract class Composer implements FieldContract
             : $this->fields;
 
         if ($this->defaults->has('field_group')) {
-            $this->fields = array_merge($this->fields ?? [], $this->defaults->get('field_group'));
+            $this->fields = array_merge($this->defaults->get('field_group'), $this->fields ?? []);
         }
     }
 


### PR DESCRIPTION
To make sure that settings on a field overwrite the default settings, the order in which those fields are merged are now reversed. When keys are the same, the second argument in `array_merge()` overwrites the first.