### PR TITLE
Add missing block render callback properties

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -282,7 +282,14 @@ abstract class Block extends Composer implements BlockContract
                 'enqueue_assets' => function () {
                     return $this->enqueue();
                 },
-                'render_callback' => function ($block, $content = '', $preview = false, $post_id = 0, $wp_block = false, $context = false) {
+                'render_callback' => function (
+                    $block,
+                    $content = '',
+                    $preview = false,
+                    $post_id = 0,
+                    $wp_block = false,
+                    $context = false
+                ) {
                     echo $this->render($block, $content, $preview, $post_id, $wp_block, $context);
                 },
             ];

--- a/src/Block.php
+++ b/src/Block.php
@@ -37,6 +37,27 @@ abstract class Block extends Composer implements BlockContract
      *
      * @param int
      */
+    public $post_id;
+
+    /**
+     * The block instance.
+     *
+     * @var \WP_Block
+     */
+    public $instance;
+
+    /**
+     * The block context.
+     *
+     * @var array
+     */
+    public $context;
+
+    /**
+     * The current post.
+     *
+     * @param \WP_Post
+     */
     public $post;
 
     /**
@@ -261,8 +282,8 @@ abstract class Block extends Composer implements BlockContract
                 'enqueue_assets' => function () {
                     return $this->enqueue();
                 },
-                'render_callback' => function ($block, $content = '', $preview = false, $post_id = 0) {
-                    echo $this->render($block, $content, $preview, $post_id);
+                'render_callback' => function ($block, $content = '', $preview = false, $post_id = 0, $wp_block = false, $context = false) {
+                    echo $this->render($block, $content, $preview, $post_id, $wp_block, $context);
                 },
             ];
 
@@ -290,14 +311,16 @@ abstract class Block extends Composer implements BlockContract
      * @param  int $post_id
      * @return string
      */
-    public function render($block, $content = '', $preview = false, $post_id = 0)
+    public function render($block, $content = '', $preview = false, $post_id = 0, $wp_block = false, $context = false)
     {
         $this->block = (object) $block;
         $this->content = $content;
         $this->preview = $preview;
+        $this->post_id = $post_id;
+        $this->instance = $wp_block;
+        $this->context = $context;
 
         $this->post = get_post($post_id);
-        $this->post_id = $post_id;
 
         $this->classes = collect([
             'slug' => Str::start(

--- a/src/Block.php
+++ b/src/Block.php
@@ -312,10 +312,12 @@ abstract class Block extends Composer implements BlockContract
     /**
      * Render the ACF block.
      *
-     * @param  array $block
-     * @param  string $content
-     * @param  bool $preview
-     * @param  int $post_id
+     * @param  array     $block
+     * @param  string    $content
+     * @param  bool      $preview
+     * @param  int       $post_id
+     * @param  \WP_Block $wp_block
+     * @param  array     $context
      * @return string
      */
     public function render($block, $content = '', $preview = false, $post_id = 0, $wp_block = false, $context = false)


### PR DESCRIPTION
## Change log

- enhance(block): Add `$context` param to block render callback (Fixes #130)
- enhance(block): Add `$wp_block` param to block render callback
- enhance(block): Add `$block->context` property to access `$context`
- enhance(block): Add `$block->instance` property to access `$wp_block`
- chore(block): Add missing `$post_id` property definition