### PR TITLE
enhancement: Add Ancestor allow list to block settings

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -138,6 +138,13 @@ abstract class Block extends Composer implements BlockContract
     public $parent = [];
 
     /**
+     * The ancestor block type allow list.
+     *
+     * @var array
+     */
+    public $ancestor = [];
+
+    /**
      * The block post type allow list.
      *
      * @var array
@@ -272,6 +279,7 @@ abstract class Block extends Composer implements BlockContract
                 'icon' => $this->icon,
                 'keywords' => $this->keywords,
                 'parent' => $this->parent ?: null,
+                'anscestor' => $this->anscestor ?: null,
                 'post_types' => $this->post_types,
                 'mode' => $this->mode,
                 'align' => $this->align,


### PR DESCRIPTION
There's a block setting to allow for possible ancestors instead of direct parents

https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/#child-innerblocks-parent-and-ancestors