### PR TITLE
enhancement: Add Ancestor allow list to block settings

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -138,6 +138,13 @@ abstract class Block extends Composer implements BlockContract
     public $parent = [];
 
     /**
+     * The ancestor block type allow list.
+     *
+     * @var array
+     */
+    public $ancestor = [];
+
+    /**
      * The block post type allow list.
      *
      * @var array
@@ -272,6 +279,7 @@ abstract class Block extends Composer implements BlockContract
                 'icon' => $this->icon,
                 'keywords' => $this->keywords,
                 'parent' => $this->parent ?: null,
+                'ancestor' => $this->ancestor ?: null,
                 'post_types' => $this->post_types,
                 'mode' => $this->mode,
                 'align' => $this->align,

--- a/src/Console/stubs/block.construct.stub
+++ b/src/Console/stubs/block.construct.stub
@@ -67,6 +67,13 @@ class DummyClass extends Block
         $this->parent = [];
 
         /**
+         * The ancestor block type allow list.
+         *
+         * @var array
+         */
+        $this->ancestor = [];
+
+        /**
          * The default block mode.
          *
          * @var string

--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -57,6 +57,13 @@ class DummyClass extends Block
     public $parent = [];
 
     /**
+     * The ancestor block type allow list.
+     *
+     * @var array
+     */
+    public $ancestor = [];
+
+    /**
      * The default block mode.
      *
      * @var string


### PR DESCRIPTION
Adds the ability to define allowed ancestors rather than direct parents.

https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/#child-innerblocks-parent-and-ancestors