### PR TITLE
enhance: pass block data to enqueue method

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -279,8 +279,8 @@ abstract class Block extends Composer implements BlockContract
                 'align_content' => $this->align_content,
                 'styles' => $this->styles,
                 'supports' => $this->supports,
-                'enqueue_assets' => function () {
-                    return $this->enqueue();
+                'enqueue_assets' => function ($block) {
+                    return $this->enqueue($block);
                 },
                 'render_callback' => function (
                     $block,


### PR DESCRIPTION
Ref #144 and #143 

I have played about locally on this and seems we can simply pass the `$block` array to the `enqueue` method which gives access to `$block['data']['my_field_name']`. This allowed me to conditionally enqueue assets depending on field values.

This PR needs more work like adding the argument to `Block::enqueue($data = [])` but I opened the PR just to get the ball rolling on this. It would result in a breaking change since the signature has changed.

@Log1x - anything to add to this? Not as nice as `get_field` in the method but hey it works.