### PR TITLE
feat(block): Add support for InnerBlocks templates

### DIFF
--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -131,6 +131,16 @@ class DummyClass extends Block
     ];
 
     /**
+     * The block template.
+     *
+     * @var array
+     */
+    public $template = [
+        'core/heading' => ['placeholder' => 'Hello World'],
+        'core/paragraph' => ['placeholder' => 'Welcome to the DummyTitle block.'],
+    ];
+    
+    /**
      * Data to be passed to the block before rendering.
      *
      * @return array

--- a/src/Console/stubs/views/block.stub
+++ b/src/Console/stubs/views/block.stub
@@ -10,6 +10,6 @@
   @endif
 
   <div>
-    <InnerBlocks />
+    <InnerBlocks template="{{ $block->template }}" />
   </div>
 </div>


### PR DESCRIPTION
This PR adds native support for the [InnerBlocks `template` property](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/#template) making it easy + clean to add block templates to your ACF blocks.

A simple template adding a heading and paragraph would look something like:

```php
public $template = [
    'core/heading' => ['placeholder' => 'Hello World'],
    'core/paragraph' => ['placeholder' => 'Welcome to the Example block.'],
];
```

I couldn't get block nesting as [pretty as I wanted](https://github.com/Log1x/acf-composer/blob/50af8c2c1f69b7584947ab2ed78cc6c47e1e29b3/src/Block.php#L234-L253) (e.g. when using `core/column` and `core/columns`) but it can be done using the `innerBlocks` attribute.

```php
public $template = [
    'core/heading' => ['placeholder' => 'Hello World'],
    'core/columns' => [
        'innerBlocks' => [
            ['core/column' => [
                'innerBlocks' => [
                    ['core/heading' => ['level' => '3', 'placeholder' => 'This is a column heading.']],
                    ['core/paragraph' => ['placeholder' => 'This is a column paragraph.']],
                ],
            ]],
            ['core/column' => [
                'innerBlocks' => [
                    ['core/image' => []],
                ],
            ]],
        ],
    ],
];
```

After adding the `$template` property to your block class you would then pass `$block->template` to `template` in `<InnerBlocks />`.

```php
<InnerBlocks template="{{ $block->template }}" />
```

Open to feedback/suggestions.