### PR TITLE
Register paths on acf/init

### DIFF
--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -59,7 +59,10 @@ class AcfComposer
     public function __construct(Application $app)
     {
         $this->app = $app;
-        $this->registerPath($this->app->path());
+
+        add_action('acf/init', function() {
+            $this->registerPath($this->app->path());
+        });
     }
 
     /**

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -77,15 +77,13 @@ abstract class Composer implements FieldContract
             return;
         }
 
-        add_filter('init', function () use ($callback) {
-            if ($callback) {
-                $callback();
-            }
+        if ($callback) {
+            $callback();
+        }
 
-            acf_add_local_field_group(
-                $this->build($this->fields)
-            );
-        }, 20);
+        acf_add_local_field_group(
+            $this->build($this->fields)
+        );
     }
 
     /**


### PR DESCRIPTION
I encountered that i cannot use acfs´s `get_field()` within my field declarations. https://github.com/Log1x/acf-composer/issues/162

I noticed that all code is executed immediately and is not registered with the acf/init hook. After changing that it is now possible to use acf related code. This might even fix https://github.com/Log1x/acf-composer/issues/94

I did some test and with these adjustments i was able to create field groups, blocks, options and widgets through the cli. 

The thing I am not sure about is the [registerPlugin](https://github.com/Log1x/acf-composer/blob/146b08dec2723f84ac2c26a3d31dc52934bba8ed/src/AcfComposer.php#LL130C25-L130C25) function. It also registers the path but i didn´t get my head around what this functions does or when it is called. Maybe it needs to be wrapped around the action hook too. 