### PR TITLE
🧑‍💻 Properly implement context throughout the Builder (Fixes #197)

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -239,10 +239,22 @@ abstract class Block extends Composer implements BlockContract
     /**
      * Assets enqueued when rendering the block.
      *
+     * @return void
+     *
+     * @deprecated Use `assets($block)` instead.
+     */
+    public function enqueue()
+    {
+        //
+    }
+
+    /**
+     * Assets enqueued when rendering the block.
+     *
      * @param  array  $block
      * @return void
      */
-    public function enqueue($block = [])
+    public function assets($block)
     {
         //
     }
@@ -360,7 +372,7 @@ abstract class Block extends Composer implements BlockContract
                 'align_content' => $this->align_content,
                 'styles' => $this->styles,
                 'supports' => $this->supports,
-                'enqueue_assets' => fn ($block) => $this->enqueue($block),
+                'enqueue_assets' => fn ($block) => $this->assets($block ?? []),
                 'render_callback' => function (
                     $block,
                     $content = '',

--- a/src/Builder/FieldBuilder.php
+++ b/src/Builder/FieldBuilder.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Log1x\AcfComposer\Builder;
+
+use Log1x\AcfComposer\Builder;
+use StoutLogic\AcfBuilder\FieldBuilder as FieldBuilderBase;
+use StoutLogic\AcfBuilder\FieldsBuilder;
+use StoutLogic\AcfBuilder\LocationBuilder;
+
+/**
+ * Builds configurations for an ACF Field.
+ *
+ * @method Builder addLayout(string|FieldsBuilder $layout, array $args = [])
+ * @method Builder endFlexibleContent()
+ * @method Builder endGroup()
+ * @method Builder endRepeater()
+ * @method FieldBuilder addCheckbox(string $name, array $args = [])
+ * @method FieldBuilder addChoiceField(string $name, string $type, array $args = [])
+ * @method FieldBuilder addColorPicker(string $name, array $args = [])
+ * @method FieldBuilder addDatePicker(string $name, array $args = [])
+ * @method FieldBuilder addDateTimePicker(string $name, array $args = [])
+ * @method FieldBuilder addEmail(string $name, array $args = [])
+ * @method FieldBuilder addField(string $name, string $type, array $args = [])
+ * @method FieldBuilder addFields(FieldsBuilder|array $fields)
+ * @method FieldBuilder addFile(string $name, array $args = [])
+ * @method FieldBuilder addGallery(string $name, array $args = [])
+ * @method FieldBuilder addGoogleMap(string $name, array $args = [])
+ * @method FieldBuilder addImage(string $name, array $args = [])
+ * @method FieldBuilder addLink(string $name, array $args = [])
+ * @method FieldBuilder addMessage(string $label, string $message, array $args = [])
+ * @method FieldBuilder addNumber(string $name, array $args = [])
+ * @method FieldBuilder addOembed(string $name, array $args = [])
+ * @method FieldBuilder addPageLink(string $name, array $args = [])
+ * @method FieldBuilder addPartial(string $partial)
+ * @method FieldBuilder addPassword(string $name, array $args = [])
+ * @method FieldBuilder addPostObject(string $name, array $args = [])
+ * @method FieldBuilder addRadio(string $name, array $args = [])
+ * @method FieldBuilder addRange(string $name, array $args = [])
+ * @method FieldBuilder addRelationship(string $name, array $args = [])
+ * @method FieldBuilder addSelect(string $name, array $args = [])
+ * @method FieldBuilder addTab(string $label, array $args = [])
+ * @method FieldBuilder addTaxonomy(string $name, array $args = [])
+ * @method FieldBuilder addText(string $name, array $args = [])
+ * @method FieldBuilder addTextarea(string $name, array $args = [])
+ * @method FieldBuilder addTimePicker(string $name, array $args = [])
+ * @method FieldBuilder addTrueFalse(string $name, array $args = [])
+ * @method FieldBuilder addUrl(string $name, array $args = [])
+ * @method FieldBuilder addUser(string $name, array $args = [])
+ * @method FieldBuilder addWysiwyg(string $name, array $args = [])
+ * @method FlexibleContentBuilder addFlexibleContent(string $name, array $args = [])
+ * @method GroupBuilder addGroup(string $name, array $args = [])
+ * @method GroupBuilder end()
+ * @method LocationBuilder setLocation(string $param, string $operator, string $value)
+ * @method RepeaterBuilder addRepeater(string $name, array $args = [])
+ */
+class FieldBuilder extends FieldBuilderBase
+{
+    //
+}

--- a/src/Builder/FlexibleContentBuilder.php
+++ b/src/Builder/FlexibleContentBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Log1x\AcfComposer\Builder;
+
+use Log1x\AcfComposer\Builder;
+use StoutLogic\AcfBuilder\FieldsBuilder;
+use StoutLogic\AcfBuilder\FlexibleContentBuilder as FieldBuilder;
+
+class FlexibleContentBuilder extends FieldBuilder
+{
+    /**
+     * Add a layout to the Flexible Content field.
+     *
+     * @param  string|FieldsBuilder  $layout
+     * @param  array  $args
+     * @return \Log1x\AcfComposer\Builder
+     */
+    public function addLayout($layout, $args = [])
+    {
+        if ($layout instanceof FieldsBuilder) {
+            $layout = clone $layout;
+        } else {
+            $layout = Builder::make($layout, $args);
+        }
+
+        $layout = $this->initializeLayout($layout, $args);
+
+        $this->pushLayout($layout);
+
+        return $layout;
+    }
+}

--- a/src/Builder/GroupBuilder.php
+++ b/src/Builder/GroupBuilder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Log1x\AcfComposer\Builder;
+
+use Log1x\AcfComposer\Builder;
+use StoutLogic\AcfBuilder\GroupBuilder as GroupBuilderBase;
+
+class GroupBuilder extends GroupBuilderBase
+{
+    /**
+     * The fields builder instance.
+     *
+     * @var \Log1x\AcfComposer\Builder
+     */
+    protected $fieldsBuilder;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($name, $type = 'group', $config = [])
+    {
+        parent::__construct($name, $type, $config);
+
+        $this->fieldsBuilder = Builder::make($name);
+
+        $this->fieldsBuilder->setParentContext($this);
+    }
+}

--- a/src/Builder/RepeaterBuilder.php
+++ b/src/Builder/RepeaterBuilder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Log1x\AcfComposer\Builder;
+
+use Log1x\AcfComposer\Builder;
+use StoutLogic\AcfBuilder\RepeaterBuilder as GroupBuilder;
+
+class RepeaterBuilder extends GroupBuilder
+{
+    /**
+     * The fields builder instance.
+     *
+     * @var \Log1x\AcfComposer\Builder
+     */
+    protected $fieldsBuilder;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($name, $type = 'repeater', $config = [])
+    {
+        parent::__construct($name, $type, $config);
+
+        $this->fieldsBuilder = Builder::make($name);
+
+        $this->fieldsBuilder->setParentContext($this);
+    }
+}

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -42,7 +42,9 @@ class UpgradeCommand extends Command
         $this->replacements = [
             'use StoutLogic\\AcfBuilder\\FieldsBuilder;' => 'use Log1x\\AcfComposer\\Builder;',
             'new FieldsBuilder(' => 'Builder::make(',
-            'public function enqueue()' => 'public function enqueue($block = [])',
+            'public function enqueue($block)' => 'public function assets($block)',
+            'public function enqueue($block = [])' => 'public function assets($block)',
+            'public function enqueue()' => 'public function assets($block)',
             '/->addFields\(\$this->get\((.*?)\)\)/' => fn ($match) => "->addPartial({$match[1]})",
         ];
 

--- a/src/Console/stubs/block.construct.stub
+++ b/src/Console/stubs/block.construct.stub
@@ -200,7 +200,7 @@ class DummyClass extends Block
      * @param  array $block
      * @return void
      */
-    public function enqueue($block = [])
+    public function assets($block)
     {
         //
     }

--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -197,7 +197,7 @@ class DummyClass extends Block
      * @param  array $block
      * @return void
      */
-    public function enqueue($block = [])
+    public function assets($block)
     {
         //
     }


### PR DESCRIPTION
## Change log

### Enhancements

- 🧑‍💻 Properly implement context throughout the `Builder` (Fixes #197)
- 🗑️ Deprecate `enqueue()` in place of `assets($block)`
- 🧑‍💻 Update the upgrade command to replace `enqueue()` with `assets($block)`