### PR TITLE
fix class Exception not found in Composer.php

### DIFF
--- a/src/Composer.php
+++ b/src/Composer.php
@@ -2,6 +2,7 @@
 
 namespace Log1x\AcfComposer;
 
+use Exception;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Log1x\AcfComposer\Concerns\InteractsWithPartial;


### PR DESCRIPTION
This is a fix for issue #205 
It adds `use Exception;` to `Composer.php` to prevent the error `Class "Log1x\AcfComposer\Exception" not found`