### PR TITLE
Fixed an issue with getTemplate

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -299,10 +299,15 @@ abstract class Block extends Composer implements BlockContract
      * Returns the block template.
      *
      * @param  array  $template
-     * @return \Illuminate\Support\Collection
+     * @return string|\Illuminate\Support\Collection
      */
     public function getTemplate($template = [])
     {
+
+        if (is_string($template)) {
+            return $template;
+        }
+
         return collect($template)->map(function ($value, $key) {
             if (is_array($value) && Arr::has($value, 'innerBlocks')) {
                 $innerBlocks = collect($value['innerBlocks'])->map(function ($innerBlock) {
@@ -313,7 +318,7 @@ abstract class Block extends Composer implements BlockContract
             }
 
             return [$key, $value];
-        })->values();
+        })->values()->toJson();
     }
 
     /**
@@ -461,7 +466,7 @@ abstract class Block extends Composer implements BlockContract
         ])->filter()->implode(' ');
 
         $this->style = $this->getStyle();
-        $this->template = $this->getTemplate($this->template)->toJson();
+        $this->template = $this->getTemplate($this->template);
 
         $this->inlineStyle = $this->getInlineStyle();
 


### PR DESCRIPTION
Hey @Log1x and thanks for updating acf-composer to v3. Massive improvement! 

I just starting to testing it all out on my local and I noticed an memory issue when our Rankmath SEO plugin was generating our sitemap. If the sitemap for example has over 30 URL per page the memory gets exhausted.

I have traced it back to the this line:
https://github.com/Log1x/acf-composer/blob/21f654dbaa6737878661f5b5f24c465cddbd7b67/src/Block.php#L464

I guess with the new caching `$this->template` gets saved on the first built and then carried over to the next time it needs built. If you have a page with a block that are used over 3 times, then it causes a problem. `$this->template` simply gets converted into JSON string everytime. Even if `$this->template` is a string it gets encoded again into JSON. 
On a single page with 10+ blocks its fine, but 30 pages with 300 blocks the `$this->template` gets massive. Therefore memory getting exhausted. 

Here is a simple log trace here for one page:
```shell
[2024-02-29 09:54:38] development.INFO: --------start------  
[2024-02-29 09:54:38] development.DEBUG: array (
)  
[2024-02-29 09:54:38] development.INFO: $this->template is an array  
[2024-02-29 09:54:38] development.INFO: block_0570b2c5cc8bfcfdc943cec707a72885  
[2024-02-29 09:54:38] development.INFO: acf/card  
[2024-02-29 09:54:38] development.INFO: ----------------  
[2024-02-29 09:54:38] development.DEBUG: array (
)  
[2024-02-29 09:54:38] development.INFO: $this->template is an array  
[2024-02-29 09:54:38] development.INFO: block_bce403ff683e0a19cbad0345bc3dc085  
[2024-02-29 09:54:38] development.INFO: acf/cards  
[2024-02-29 09:54:38] development.INFO: ----------------   
[2024-02-29 09:54:38] development.DEBUG: []  
[2024-02-29 09:54:38] development.INFO: $this->template is a string  
[2024-02-29 09:54:38] development.INFO: block_a7854c9d55706858e5a2316efdd49e18  
[2024-02-29 09:54:38] development.INFO: acf/cards  
[2024-02-29 09:54:38] development.INFO: ----------------  
[2024-02-29 09:54:38] development.DEBUG: array (
)  
[2024-02-29 09:54:38] development.INFO: $this->template is an array  
[2024-02-29 09:54:38] development.INFO: block_4d1d827b32f857a974de99fa5b9fbfc1  
[2024-02-29 09:54:38] development.INFO: acf/content-hub  
[2024-02-29 09:54:38] development.INFO: ----------------  
[2024-02-29 09:54:39] development.DEBUG: array (
)  
[2024-02-29 09:54:39] development.INFO: $this->template is an array  
[2024-02-29 09:54:39] development.INFO: block_d9e560c6993edeb4d3c99910af4e85fa  
[2024-02-29 09:54:39] development.INFO: acf/button  
[2024-02-29 09:54:39] development.INFO: ----------------  
[2024-02-29 09:54:39] development.DEBUG: array (           <------- first time - array
)  
[2024-02-29 09:54:39] development.INFO: $this->template is an array  
[2024-02-29 09:54:39] development.INFO: block_0bb5d3dc0936f9b1fed8de9886b53def  
[2024-02-29 09:54:39] development.INFO: acf/square-container  
[2024-02-29 09:54:39] development.INFO: ----------------  
[2024-02-29 09:54:39] development.DEBUG: []                     <------- second time - string
[2024-02-29 09:54:39] development.INFO: $this->template is a string  
[2024-02-29 09:54:39] development.INFO: block_2a1170816eddc6834f86950b6d36295e  
[2024-02-29 09:54:39] development.INFO: acf/button  
[2024-02-29 09:54:39] development.INFO: ----------------   
[2024-02-29 09:54:39] development.DEBUG: []  
[2024-02-29 09:54:39] development.INFO: $this->template is a string  
[2024-02-29 09:54:39] development.INFO: block_ea4596f6c1ac8bd3ea6bc6ddc8ae127c  
[2024-02-29 09:54:39] development.INFO: acf/square-container  
[2024-02-29 09:54:39] development.INFO: ----------------  
[2024-02-29 09:54:39] development.DEBUG: [[0,"[]"]]         <------- third time - corrupted string
[2024-02-29 09:54:39] development.INFO: $this->template is a string  
[2024-02-29 09:54:39] development.INFO: block_bf3f47f7a6a47bad3bf12435cbaca750  
[2024-02-29 09:54:39] development.INFO: acf/button  
[2024-02-29 09:54:39] development.INFO: ----------------  
[2024-02-29 09:54:39] development.DEBUG: array (
)  
[2024-02-29 09:54:39] development.INFO: $this->template is an array  
[2024-02-29 09:54:39] development.INFO: block_8ef38eb7eb2dd5ecbde42f97a522bc79  
[2024-02-29 09:54:39] development.INFO: acf/logos  
[2024-02-29 09:54:39] development.INFO: ----------------  
``` 
Notice the third time "acf/button" is being used at the DEBUG line. `$this->template` is now `[[0,"[]"]]`.

I have made a PR that should fix the problem of `$this->template` being converted recursively. If the `$this->template` is a string then return the string. Otherwise it should just contiune normally. 