### PR TITLE
✨ Add an attributes() method for cleanly & safely setting block properties instead of construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ class Example extends Block
 }
 ```
 
-You may also pass `--construct` to the command above to generate a stub with the block properties set within the constructor. This can be useful for localization, etc.
+You may also pass `--construct` to the command above to generate a stub with the block properties set within an `attributes` method. This can be useful for localization, etc.
 
 ```bash
 $ wp acorn acf:block Example --construct

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -42,9 +42,10 @@ class UpgradeCommand extends Command
         $this->replacements = [
             'use StoutLogic\\AcfBuilder\\FieldsBuilder;' => 'use Log1x\\AcfComposer\\Builder;',
             'new FieldsBuilder(' => 'Builder::make(',
-            'public function enqueue($block)' => 'public function assets($block)',
-            'public function enqueue($block = [])' => 'public function assets($block)',
-            'public function enqueue()' => 'public function assets($block)',
+            'public function assets($block)' => 'public function assets(array $block): void',
+            'public function enqueue($block)' => 'public function assets(array $block): void',
+            'public function enqueue($block = [])' => 'public function assets(array $block): void',
+            'public function enqueue()' => 'public function assets(array $block): void',
             '/->addFields\(\$this->get\((.*?)\)\)/' => fn ($match) => "->addPartial({$match[1]})",
         ];
 

--- a/src/Console/stubs/block.construct.stub
+++ b/src/Console/stubs/block.construct.stub
@@ -8,159 +8,65 @@ use Log1x\AcfComposer\Builder;
 
 class DummyClass extends Block
 {
-    public function __construct(AcfComposer $composer)
+    /**
+     * The block attributes.
+     */
+    public function attributes(): array
     {
-        /**
-         * The block name.
-         *
-         * @var string
-         */
-        $this->name = __('DummyTitle', 'sage');
-
-        /**
-         * The block slug.
-         *
-         * @var string
-         */
-        $this->slug = 'DummySlug';
-
-        /**
-         * The block description.
-         *
-         * @var string
-         */
-        $this->description = __('A simple DummyTitle block.', 'sage');
-
-        /**
-         * The block category.
-         *
-         * @var string
-         */
-        $this->category = 'formatting';
-
-        /**
-         * The block icon.
-         *
-         * @var string|array
-         */
-        $this->icon = 'editor-ul';
-
-        /**
-         * The block keywords.
-         *
-         * @var array
-         */
-        $this->keywords = [];
-
-        /**
-         * The block post type allow list.
-         *
-         * @var array
-         */
-        $this->post_types = [];
-
-        /**
-         * The parent block type allow list.
-         *
-         * @var array
-         */
-        $this->parent = [];
-
-        /**
-         * The ancestor block type allow list.
-         *
-         * @var array
-         */
-        $this->ancestor = [];
-
-        /**
-         * The default block mode.
-         *
-         * @var string
-         */
-        $this->mode = 'preview';
-
-        /**
-         * The default block alignment.
-         *
-         * @var string
-         */
-        $this->align = '';
-
-        /**
-         * The default block text alignment.
-         *
-         * @var string
-         */
-        $this->align_text = '';
-
-        /**
-         * The default block content alignment.
-         *
-         * @var string
-         */
-        $this->align_content = '';
-
-        /**
-         * The supported block features.
-         *
-         * @var array
-         */
-        $this->supports = [
-            'align' => true,
-            'align_text' => false,
-            'align_content' => false,
-            'full_height' => false,
-            'anchor' => false,
-            'mode' => false,
-            'multiple' => true,
-            'jsx' => true,
-            'color' => [
-                'background' => true,
-                'text' => true,
-                'gradient' => true,
+        return [
+            'name' => __('DummyTitle', 'sage'),
+            'description' => __('A simple DummyTitle block.', 'sage'),
+            'category' => 'formatting',
+            'icon' => 'editor-ul',
+            'keywords' => [],
+            'post_types' => [],
+            'parent' => [],
+            'ancestor' => [],
+            'mode' => 'preview',
+            'align' => '',
+            'align_text' => '',
+            'align_content' => '',
+            'supports' => [
+                'align' => true,
+                'align_text' => false,
+                'align_content' => false,
+                'full_height' => false,
+                'anchor' => false,
+                'mode' => false,
+                'multiple' => true,
+                'jsx' => true,
+                'color' => [
+                    'background' => true,
+                    'text' => true,
+                    'gradient' => true,
+                ],
+            ],
+            'styles' => ['light', 'dark'],
+            'template' => [
+                'core/heading' => ['placeholder' => 'Hello World'],
+                'core/paragraph' => ['placeholder' => 'Welcome to the DummyTitle block.'],
             ],
         ];
+    }
 
-        /**
-         * The block styles.
-         *
-         * @var array
-         */
-        $this->styles = [
-            [
-                'name' => 'light',
-                'label' => 'Light',
-                'isDefault' => true,
+    /**
+     * The example data.
+     */
+    public function example(): array
+    {
+        return [
+            'items' => [
+                ['item' => 'Item onez'],
+                ['item' => 'Item two'],
+                ['item' => 'Item three'],
             ],
-            [
-                'name' => 'dark',
-                'label' => 'Dark',
-            ]
         ];
-
-        /**
-         * The block preview example data.
-         *
-         * @var array
-         */
-        $this->example = [
-           'items' => [
-               ['item' => 'Item one'],
-               ['item' => 'Item two'],
-               ['item' => 'Item three'],
-           ],
-        ];
-
-        parent::__construct($composer);
     }
 
     /**
      * Data to be passed to the block before rendering.
-     *
-     * @return array
      */
-    public function with()
+    public function with(): array
     {
         return [
             'items' => $this->items(),
@@ -169,10 +75,8 @@ class DummyClass extends Block
 
     /**
      * The block field group.
-     *
-     * @return array
      */
-    public function fields()
+    public function fields(): array
     {
         $DummyCamel = Builder::make('DummySnake');
 
@@ -196,11 +100,8 @@ class DummyClass extends Block
 
     /**
      * Assets enqueued when rendering the block.
-     *
-     * @param  array $block
-     * @return void
      */
-    public function assets($block)
+    public function assets(array $block): void
     {
         //
     }

--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -180,7 +180,7 @@ class DummyClass extends Block
     /**
      * Assets enqueued when rendering the block.
      */
-    public function assets(array $block):void
+    public function assets(array $block): void
     {
         //
     }

--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -117,17 +117,7 @@ class DummyClass extends Block
      *
      * @var array
      */
-    public $styles = [
-        [
-            'name' => 'light',
-            'label' => 'Light',
-            'isDefault' => true,
-        ],
-        [
-            'name' => 'dark',
-            'label' => 'Dark',
-        ]
-    ];
+    public $styles = ['light', 'dark'];
 
     /**
      * The block preview example data.
@@ -154,10 +144,8 @@ class DummyClass extends Block
 
     /**
      * Data to be passed to the block before rendering.
-     *
-     * @return array
      */
-    public function with()
+    public function with(): array
     {
         return [
             'items' => $this->items(),
@@ -166,10 +154,8 @@ class DummyClass extends Block
 
     /**
      * The block field group.
-     *
-     * @return array
      */
-    public function fields()
+    public function fields(): array
     {
         $DummyCamel = Builder::make('DummySnake');
 
@@ -193,11 +179,8 @@ class DummyClass extends Block
 
     /**
      * Assets enqueued when rendering the block.
-     *
-     * @param  array $block
-     * @return void
      */
-    public function assets($block)
+    public function assets(array $block):void
     {
         //
     }

--- a/src/Console/stubs/field.stub
+++ b/src/Console/stubs/field.stub
@@ -9,10 +9,8 @@ class DummyClass extends Field
 {
     /**
      * The field group.
-     *
-     * @return array
      */
-    public function fields()
+    public function fields(): array
     {
         $DummyCamel = Builder::make('DummySnake');
 

--- a/src/Console/stubs/options.full.stub
+++ b/src/Console/stubs/options.full.stub
@@ -93,30 +93,24 @@ class DummyClass extends Field
 
     /**
      * Localized text displayed on the submit button.
-     *
-     * @return string
      */
-    public function updateButton()
+    public function updateButton(): string
     {
         return __('Update', 'acf');
     }
 
     /**
      * Localized text displayed after form submission.
-     *
-     * @return string
      */
-    public function updatedMessage()
+    public function updatedMessage(): string
     {
         return __('DummyTitle Updated', 'acf');
     }
 
     /**
      * The option page field group.
-     *
-     * @return array
      */
-    public function fields()
+    public function fields(): array
     {
         $DummyCamel = Builder::make('DummySnake');
 

--- a/src/Console/stubs/options.stub
+++ b/src/Console/stubs/options.stub
@@ -23,10 +23,8 @@ class DummyClass extends Field
 
     /**
      * The option page field group.
-     *
-     * @return array
      */
-    public function fields()
+    public function fields(): array
     {
         $DummyCamel = Builder::make('DummySnake');
 

--- a/src/Console/stubs/partial.stub
+++ b/src/Console/stubs/partial.stub
@@ -9,10 +9,8 @@ class DummyClass extends Partial
 {
     /**
      * The partial field group.
-     *
-     * @return \Log1x\AcfComposer\Builder
      */
-    public function fields()
+    public function fields(): Builder
     {
         $DummyCamel = Builder::make('DummySnake');
 

--- a/src/Console/stubs/widget.stub
+++ b/src/Console/stubs/widget.stub
@@ -23,10 +23,8 @@ class DummyClass extends Widget
 
     /**
      * Data to be passed to the widget before rendering.
-     *
-     * @return array
      */
-    public function with()
+    public function with(): array
     {
         return [
             'items' => $this->items(),
@@ -35,20 +33,16 @@ class DummyClass extends Widget
 
     /**
      * The widget title.
-     *
-     * @return string
      */
-    public function title()
+    public function title(): string
     {
         return get_field('title', $this->widget->id);
     }
 
     /**
      * The widget field group.
-     *
-     * @return array
      */
-    public function fields()
+    public function fields(): array
     {
         $DummyCamel = Builder::make('DummySnake');
 


### PR DESCRIPTION
## Change log

### Enhancements

- ✨ Add an `attributes()` method for cleanly & safely setting block properties instead of construct
- 🧑‍💻 Simplify required arguments for block styles
- 🎨 Improve method typing
- 🧑‍💻 Check for `assets` with `method_exists` to prevent unnecessary clashing
- 🎨 Remove unnecessary `align_content` conditional
- 🎨 Add types to stubs
- 🎨 Improve default typing on the `assets` method (Fixes #206)
- 🎨 Simplify the default `styles` property
- 🎨 Move example data into the `example()` method in the block construct stub
- 🧑‍💻 Update the assets() replacement in acf:upgrade