### PR TITLE
:pencil2: Fix typo in example data

### DIFF
--- a/src/Console/stubs/block.construct.stub
+++ b/src/Console/stubs/block.construct.stub
@@ -56,7 +56,7 @@ class DummyClass extends Block
     {
         return [
             'items' => [
-                ['item' => 'Item onez'],
+                ['item' => 'Item one'],
                 ['item' => 'Item two'],
                 ['item' => 'Item three'],
             ],


### PR DESCRIPTION
Fixes a typo in `block` stub