### PR TITLE
🚧 Implement block.json generation when caching

### DIFF
--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -198,6 +198,22 @@ class AcfComposer
     }
 
     /**
+     * Retrieve a Composer instance by class name.
+     */
+    public function getComposer(string $class): ?Composer
+    {
+        foreach ($this->composers as $composers) {
+            foreach ($composers as $composer) {
+                if ($composer::class === $class) {
+                    return $composer;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Retrieve the registered paths.
      */
     public function paths(): array

--- a/src/Block.php
+++ b/src/Block.php
@@ -401,7 +401,6 @@ abstract class Block extends Composer implements BlockContract
             $this->supports = collect($this->supports)
                 ->mapWithKeys(fn ($value, $key) => [Str::camel($key) => $value])
                 ->merge($this->supports)
-                ->unique()
                 ->all();
         }
 

--- a/src/Block.php
+++ b/src/Block.php
@@ -380,7 +380,10 @@ abstract class Block extends Composer implements BlockContract
             ]);
         }
 
-        $this->register(fn () => $this->hasJson() ? register_block_type($this->jsonPath()) : acf_register_block_type($this->settings()->all()));
+        $this->register(fn () => $this->hasJson()
+            ? register_block_type($this->jsonPath())
+            : acf_register_block_type($this->settings()->all())
+        );
 
         return $this;
     }
@@ -392,6 +395,14 @@ abstract class Block extends Composer implements BlockContract
     {
         if ($this->settings) {
             return $this->settings;
+        }
+
+        if ($this->supports) {
+            $this->supports = collect($this->supports)
+                ->mapWithKeys(fn ($value, $key) => [Str::camel($key) => $value])
+                ->merge($this->supports)
+                ->unique()
+                ->all();
         }
 
         $settings = Collection::make([
@@ -459,7 +470,7 @@ abstract class Block extends Composer implements BlockContract
         ])->put('acf', [
             'mode' => $this->mode,
             'renderTemplate' => $this::class,
-        ])->prepend(3, 'apiVersion');
+        ]);
 
         return $settings->filter()->toJson(JSON_PRETTY_PRINT);
     }

--- a/src/Block.php
+++ b/src/Block.php
@@ -457,7 +457,6 @@ abstract class Block extends Composer implements BlockContract
             'render_callback',
             'mode',
         ])->put('acf', [
-            'composer' => $this::class,
             'mode' => $this->mode,
             'renderTemplate' => $this::class,
         ])->prepend(3, 'apiVersion');

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -69,10 +69,14 @@ class CacheCommand extends Command
             return $this->components->error('Failed to cache the <fg=red>ACF Composer</> field groups.');
         }
 
-        if (! $this->composer->manifest()->write()) {
+        if (! $manifest = $this->composer->manifest()->write()) {
             return $this->components->error('Failed to write the <fg=red>ACF Composer</> manifest.');
         }
 
-        $this->components->info("<fg=blue>{$this->count}</> field group(s) cached successfully.");
+        if (! $blocks = $this->composer->manifest()->writeBlocks()) {
+            return $this->components->error('Failed to write the <fg=red>ACF Composer</> blocks.');
+        }
+
+        $this->components->info("Successfully cached <fg=blue>{$manifest}</> field(s) and <fg=blue>{$blocks}</> block(s).");
     }
 }

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -13,16 +13,17 @@ class CacheCommand extends Command
      * @var string
      */
     protected $signature = 'acf:cache
-                            {--clear : Clear the cached field groups}
+                            {--clear : Clear the cache}
                             {--status : Show the current cache status}
-                            {--force : Force cache the field groups}';
+                            {--manifest : Only write the field group manifest}
+                            {--force : Ignore errors when writing cache}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Cache the ACF field groups';
+    protected $description = 'Cache the ACF Composer field groups and blocks.';
 
     /**
      * The ACF Composer instance.
@@ -73,7 +74,9 @@ class CacheCommand extends Command
             return $this->components->error('Failed to write the <fg=red>ACF Composer</> manifest.');
         }
 
-        $blocks = $this->composer->manifest()->writeBlocks();
+        $blocks = ! $this->option('manifest')
+            ? $this->composer->manifest()->writeBlocks()
+            : 0;
 
         $this->components->info("Successfully cached <fg=blue>{$manifest}</> field(s) and <fg=blue>{$blocks}</> block(s).");
     }

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -73,9 +73,7 @@ class CacheCommand extends Command
             return $this->components->error('Failed to write the <fg=red>ACF Composer</> manifest.');
         }
 
-        if (! $blocks = $this->composer->manifest()->writeBlocks()) {
-            return $this->components->error('Failed to write the <fg=red>ACF Composer</> blocks.');
-        }
+        $blocks = $this->composer->manifest()->writeBlocks();
 
         $this->components->info("Successfully cached <fg=blue>{$manifest}</> field(s) and <fg=blue>{$blocks}</> block(s).");
     }

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -19,7 +19,7 @@ class ClearCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Clear the ACF field group cache';
+    protected $description = 'Clear the ACF Composer cache.';
 
     /**
      * The ACF Composer instance.
@@ -34,7 +34,7 @@ class ClearCommand extends Command
         $this->composer = $this->laravel['AcfComposer'];
 
         return $this->composer->manifest()->delete()
-            ? $this->components->info('Successfully cleared the <fg=blue>ACF Composer</> cache manifest.')
-            : $this->components->info('The <fg=blue>ACF Composer</> cache manifest is already cleared.');
+            ? $this->components->info('Successfully cleared the <fg=blue>ACF Composer</> cache.')
+            : $this->components->info('The <fg=blue>ACF Composer</> cache is already cleared.');
     }
 }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -107,23 +107,35 @@ class Manifest
     /**
      * Write the the manifest to disk.
      */
-    public function write(): bool
+    public function write(): ?int
     {
         File::ensureDirectoryExists($this->path);
 
-        if ($this->blocks) {
-            $path = $this->path('blocks');
-
-            foreach ($this->blocks as $path => $block) {
-                File::ensureDirectoryExists(dirname($path));
-                File::put($path, $block);
-            }
-        }
+        $manifest = $this->toArray();
 
         return file_put_contents(
             $this->path(),
-            '<?php return '.var_export($this->toArray(), true).';'
-        ) !== false;
+            '<?php return '.var_export($manifest, true).';'
+        ) !== false ? count($manifest) : null;
+    }
+
+    /**
+     * Write the block JSON to disk.
+     */
+    public function writeBlocks(): int
+    {
+        if (! $this->blocks) {
+            return 0;
+        }
+
+        $path = $this->path('blocks');
+
+        foreach ($this->blocks as $path => $block) {
+            File::ensureDirectoryExists(dirname($path));
+            File::put($path, $block);
+        }
+
+        return count($this->blocks);
     }
 
     /**

--- a/src/Providers/AcfComposerServiceProvider.php
+++ b/src/Providers/AcfComposerServiceProvider.php
@@ -37,8 +37,6 @@ class AcfComposerServiceProvider extends ServiceProvider
 
         $composer->handle();
 
-        $this->handleBlocks();
-
         if ($this->app->runningInConsole()) {
             $this->commands([
                 Console\BlockMakeCommand::class,
@@ -60,25 +58,5 @@ class AcfComposerServiceProvider extends ServiceProvider
                 ]);
             }
         }
-    }
-
-    /**
-     * Handle the block rendering.
-     */
-    protected function handleBlocks(): void
-    {
-        add_filter('acf_block_render_template', function ($block, $content, $is_preview, $post_id, $wp_block, $context) {
-            if (! class_exists($composer = $block['render_template'] ?? '')) {
-                return;
-            }
-
-            if (! $composer = app('AcfComposer')->getComposer($composer)) {
-                return;
-            }
-
-            method_exists($composer, 'assets') && $composer->assets($block);
-
-            echo $composer->render($block, $content, $is_preview, $post_id, $wp_block, $context);
-        }, 10, 6);
     }
 }

--- a/src/Providers/AcfComposerServiceProvider.php
+++ b/src/Providers/AcfComposerServiceProvider.php
@@ -64,7 +64,13 @@ class AcfComposerServiceProvider extends ServiceProvider
                 return;
             }
 
-            echo app('AcfComposer')->getComposer($composer)->render($block, $content, $is_preview, $post_id, $wp_block, $context);
+            if (! $composer = app('AcfComposer')->getComposer($composer)) {
+                return;
+            }
+
+            method_exists($composer, 'assets') && $composer->assets($block);
+
+            echo $composer->render($block, $content, $is_preview, $post_id, $wp_block, $context);
         }, 10, 6);
     }
 }

--- a/src/Providers/AcfComposerServiceProvider.php
+++ b/src/Providers/AcfComposerServiceProvider.php
@@ -58,5 +58,13 @@ class AcfComposerServiceProvider extends ServiceProvider
                 'Version' => InstalledVersions::getPrettyVersion('log1x/acf-composer'),
             ]);
         }
+
+        add_filter('acf_block_render_template', function ($block, $content, $is_preview, $post_id, $wp_block, $context) {
+            if (! class_exists($composer = $block['render_template'])) {
+                return;
+            }
+
+            echo app('AcfComposer')->getComposer($composer)->render($block, $content, $is_preview, $post_id, $wp_block, $context);
+        }, 10, 6);
     }
 }


### PR DESCRIPTION
This is a WIP attempt at generating and using `block.json` files when running `acf:cache` for #223 

~~It still needs style/script support but I haven't figured out the best way to pull that off while maintaining some kind of compatibility with `assets()`.~~

Please test using `composer require log1x/acf-composer:dev-feat/json-blocks` and then compile with `acorn acf:cache`.