### PR TITLE
🩹 Suppress the `template_not_found_message` when rendering cached blocks on ACF v6.3.x

### DIFF
--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -207,6 +207,8 @@ class AcfComposer
                 return;
             }
 
+            add_filter('acf/blocks/template_not_found_message', fn () => '');
+
             method_exists($composer, 'assets') && $composer->assets($block);
 
             echo $composer->render($block, $content, $is_preview, $post_id, $wp_block, $context);


### PR DESCRIPTION
A useless "The render template for this ACF Block was not found" message was added in the `acf_block_render_template` hook when a template file isn't found at some point in ACF Pro 6.3.x.

This hook still makes sense over using a render callback for ACF Composer's use-case despite us echoing the rendered output ourselves so the best workaround is emptying the message using the `acf/blocks/template_not_found_message` filter when a cached block goes to render.