### PR TITLE
Update AcfComposer.php

### DIFF
--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -198,7 +198,7 @@ class AcfComposer
      */
     protected function handleBlocks(): void
     {
-        add_filter('acf_block_render_template', function ($block, $content, $is_preview, $post_id, $wp_block, $context) {
+        add_action('acf_block_render_template', function ($block, $content, $is_preview, $post_id, $wp_block, $context) {
             if (! class_exists($composer = $block['render_template'] ?? '')) {
                 return;
             }
@@ -212,7 +212,7 @@ class AcfComposer
             method_exists($composer, 'assets') && $composer->assets($block);
 
             echo $composer->render($block, $content, $is_preview, $post_id, $wp_block, $context);
-        }, 10, 6);
+        }, 9, 6);
     }
 
     /**


### PR DESCRIPTION
If we have a look at advanced-custom-fields-pro/pro/blocks.php. The acf_block_render_template is an action.

Also need to lower the action's priority to register the add_filter('acf/blocks/template_not_found_message') before the action 'acf_block_render_template' is fired for the first time ( the one registered in ACF ).

Both registered actions have prio 10, but do to the alphabetical order, the acf_block_render_template[10] registered in ACF is fired first.