### PR TITLE
Nest cached blocks post type restrictions in the block.json acf section

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -593,10 +593,12 @@ abstract class Block extends Composer implements BlockContract
             'acf_block_version',
             'enqueue_assets',
             'mode',
+            'post_types',
             'render_callback',
             'use_post_meta',
         ])->put('acf', [
             'mode' => $this->mode,
+            'postTypes' => $this->post_types,
             'renderTemplate' => $this::class,
             'usePostMeta' => $this->usePostMeta,
         ])->put('name', $this->namespace);


### PR DESCRIPTION
Fixes #295 

This is a bug fix but could be considered a breaking change.

Scenario that could happen on a site using cached blocks:
- Block was added to a post type that did not support it
- The site is updated to a version of ACF Composer that includes this fix
- The block is still visible on the frontend but will display this message in the editor:
  > Your site doesn’t include support for the "acf/block-name" block. You can leave it as-is or remove it.