### PR TITLE
Adds `blockVersion` & `validate` settings to cached block.json

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -596,6 +596,7 @@ abstract class Block extends Composer implements BlockContract
             'post_types',
             'render_callback',
             'use_post_meta',
+            'validate',
         ])->put('acf', [
             'blockVersion' => $this->settings()->get('acf_block_version'),
             'mode' => $this->mode,

--- a/src/Block.php
+++ b/src/Block.php
@@ -259,6 +259,20 @@ abstract class Block extends Composer implements BlockContract
     public $usePostMeta = false;
 
     /**
+     * The ACF block API version.
+     *
+     * @var int
+     */
+    public $blockVersion = 2;
+
+    /**
+     * Validate block fields as per the field group configuration.
+     *
+     * @var bool
+     */
+    public $validate = true;
+
+    /**
      * The block attributes.
      */
     public function attributes(): array
@@ -536,9 +550,9 @@ abstract class Block extends Composer implements BlockContract
             'supports' => $this->supports,
             'enqueue_assets' => fn ($block) => method_exists($this, 'assets') ? $this->assets($block) : null,
             'textdomain' => $this->getTextDomain(),
-            'acf_block_version' => 2,
+            'acf_block_version' => $this->blockVersion,
             'api_version' => 2,
-            'validate' => true,
+            'validate' => $this->validate,
             'use_post_meta' => $this->usePostMeta,
             'render_callback' => function (
                 $block,
@@ -598,12 +612,12 @@ abstract class Block extends Composer implements BlockContract
             'use_post_meta',
             'validate',
         ])->put('acf', [
-            'blockVersion' => $this->settings()->get('acf_block_version'),
+            'blockVersion' => $this->blockVersion,
             'mode' => $this->mode,
             'postTypes' => $this->post_types,
             'renderTemplate' => $this::class,
             'usePostMeta' => $this->usePostMeta,
-            'validate' => $this->settings()->get('validate')
+            'validate' => $this->validate,
         ])->put('name', $this->namespace);
 
         return $settings->filter()->toJson(JSON_PRETTY_PRINT);

--- a/src/Block.php
+++ b/src/Block.php
@@ -597,10 +597,12 @@ abstract class Block extends Composer implements BlockContract
             'render_callback',
             'use_post_meta',
         ])->put('acf', [
+            'blockVersion' => $this->settings()->get('acf_block_version'),
             'mode' => $this->mode,
             'postTypes' => $this->post_types,
             'renderTemplate' => $this::class,
             'usePostMeta' => $this->usePostMeta,
+            'validate' => $this->settings()->get('validate')
         ])->put('name', $this->namespace);
 
         return $settings->filter()->toJson(JSON_PRETTY_PRINT);


### PR DESCRIPTION
Hi @Log1x,

Happy New Year! 

I have a block registered for which I need to set the `acf_block_version` to `1`. Overwriting the `settings()` method of the class `Block` like this:

```
    /**
     * Overwrite the block settings to use ACF Block Version 1.
     * This prevents the inner blocks from being wrapped into a .acf-innerblocks-container div.
     *
     * @return Collection The block settings.
     */
    public function settings(): Collection
    {
        return parent::settings()->put('acf_block_version', 1);
    }
 ```

This works perfectly as long as I do not cache the blocks.
This PR adds `blockVersion` & `validate` to the cached `blocks.json` file. Both are settings that might be relevant: https://github.com/AdvancedCustomFields/schemas/blob/7efb0ab78ce903a1414705a83b0fe9b426d5d321/json/block.json#L63

Thanks and kind regards

