### PR TITLE
Add HasCollection trait

### DIFF
--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -4,6 +4,7 @@ namespace Log1x\AcfComposer;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Log1x\AcfComposer\Concerns\HasCollection;
 use Log1x\AcfComposer\Exceptions\DuplicateKeyException;
 use ReflectionClass;
 use Roots\Acorn\Application;
@@ -11,6 +12,8 @@ use Symfony\Component\Finder\Finder;
 
 class AcfComposer
 {
+    use HasCollection;
+
     /**
      * The application instance.
      *
@@ -228,7 +231,7 @@ class AcfComposer
      */
     public function registerPath(string $path, ?string $namespace = null): array
     {
-        $paths = collect(File::directories($path))
+        $paths = $this->collect(File::directories($path))
             ->filter(fn ($item) => Str::contains($item, $this->classes));
 
         if ($paths->isEmpty()) {

--- a/src/Block.php
+++ b/src/Block.php
@@ -330,7 +330,7 @@ abstract class Block extends Composer implements BlockContract
      */
     public function getDefaultStyle(): array
     {
-        return collect($this->getStyles())->firstWhere('isDefault') ?? [];
+        return $this->collect($this->getStyles())->firstWhere('isDefault') ?? [];
     }
 
     /**
@@ -338,7 +338,7 @@ abstract class Block extends Composer implements BlockContract
      */
     public function getStyles(): array
     {
-        $styles = collect($this->styles)->map(function ($value, $key) {
+        $styles = $this->collect($this->styles)->map(function ($value, $key) {
             if (is_array($value)) {
                 return $value;
             }
@@ -368,15 +368,15 @@ abstract class Block extends Composer implements BlockContract
      */
     public function getInlineStyle(): string
     {
-        return collect([
+        return $this->collect([
             'padding' => ! empty($this->block->style['spacing']['padding'])
-                ? collect($this->block->style['spacing']['padding'])
+                ? $this->collect($this->block->style['spacing']['padding'])
                     ->map(fn ($value, $side) => $this->formatCss($value, $side))
                     ->implode(' ')
                 : null,
 
             'margin' => ! empty($this->block->style['spacing']['margin'])
-                ? collect($this->block->style['spacing']['margin'])
+                ? $this->collect($this->block->style['spacing']['margin'])
                     ->map(fn ($value, $side) => $this->formatCss($value, $side, 'margin'))
                     ->implode(' ')
                 : null,
@@ -392,7 +392,7 @@ abstract class Block extends Composer implements BlockContract
      */
     public function getClasses(): string
     {
-        $classes = collect([
+        $classes = $this->collect([
             'slug' => Str::of($this->slug)->slug()->start('wp-block-')->toString(),
 
             'className' => $this->block->className ?? null,
@@ -466,7 +466,7 @@ abstract class Block extends Composer implements BlockContract
      */
     public function handleTemplate(array $template = []): Collection
     {
-        return collect($template)->map(function ($block, $key) {
+        return $this->collect($template)->map(function ($block, $key) {
             $name = is_numeric($key)
                 ? array_key_first((array) $block)
                 : $key;
@@ -528,7 +528,7 @@ abstract class Block extends Composer implements BlockContract
         }
 
         if ($this->supports) {
-            $this->supports = collect($this->supports)
+            $this->supports = $this->collect($this->supports)
                 ->mapWithKeys(fn ($value, $key) => [Str::camel($key) => $value])
                 ->merge($this->supports)
                 ->all();

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -11,6 +11,7 @@ use Log1x\AcfComposer\Builder\FlexibleContentBuilder;
 use Log1x\AcfComposer\Builder\GroupBuilder;
 use Log1x\AcfComposer\Builder\RepeaterBuilder;
 use Log1x\AcfComposer\Builder\TabBuilder;
+use Log1x\AcfComposer\Concerns\HasCollection;
 use ReflectionClass;
 use StoutLogic\AcfBuilder\FieldsBuilder;
 use StoutLogic\AcfBuilder\LocationBuilder;
@@ -67,6 +68,8 @@ use StoutLogic\AcfBuilder\LocationBuilder;
  */
 class Builder extends FieldsBuilder
 {
+    use HasCollection;
+
     /**
      * The ACF Composer instance.
      */
@@ -128,7 +131,7 @@ class Builder extends FieldsBuilder
 
         $types = config('acf.types', []);
 
-        return $this->types = collect($types)->mapWithKeys(fn ($type, $key) => [
+        return $this->types = $this->collect($types)->mapWithKeys(fn ($type, $key) => [
             Str::of($key)->studly()->start('add')->toString() => $type,
         ])->all();
     }

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -4,6 +4,7 @@ namespace Log1x\AcfComposer;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Log1x\AcfComposer\Concerns\HasCollection;
 use Log1x\AcfComposer\Concerns\InteractsWithPartial;
 use Log1x\AcfComposer\Contracts\Composer as ComposerContract;
 use Log1x\AcfComposer\Contracts\Field as FieldContract;
@@ -13,7 +14,7 @@ use StoutLogic\AcfBuilder\FieldsBuilder;
 
 abstract class Composer implements ComposerContract, FieldContract
 {
-    use InteractsWithPartial;
+    use HasCollection, InteractsWithPartial;
 
     /**
      * The ACF Composer instance.
@@ -48,7 +49,7 @@ abstract class Composer implements ComposerContract, FieldContract
         $this->composer = $composer;
         $this->app = $composer->app;
 
-        $this->defaults = collect($this->app->config->get('acf.defaults'))
+        $this->defaults = $this->collect($this->app->config->get('acf.defaults'))
             ->merge($this->defaults)
             ->mapWithKeys(fn ($value, $key) => [Str::snake($key) => $value]);
 
@@ -144,7 +145,7 @@ abstract class Composer implements ComposerContract, FieldContract
      */
     public function build(array $fields = []): array
     {
-        return collect($fields)->map(function ($value, $key) {
+        return $this->collect($fields)->map(function ($value, $key) {
             if (
                 ! in_array($key, $this->keys) ||
                 (Str::is($key, 'type') && ! $this->defaults->has($value))

--- a/src/Concerns/HasCollection.php
+++ b/src/Concerns/HasCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Log1x\AcfComposer\Concerns;
+
+use Illuminate\Support\Collection;
+
+trait HasCollection
+{
+    /**
+     * Initialize a Collection instance.
+     *
+     * @param  string[]  $value
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($value)
+    {
+        return Collection::make($value);
+    }
+}

--- a/src/Console/BlockMakeCommand.php
+++ b/src/Console/BlockMakeCommand.php
@@ -79,19 +79,19 @@ class BlockMakeCommand extends MakeCommand
 
         $category = select(
             label: 'Select the block category',
-            options: collect($categories)->mapWithKeys(fn ($category) => [$category['slug'] => $category['title']]),
+            options: $this->collect($categories)->mapWithKeys(fn ($category) => [$category['slug'] => $category['title']]),
             default: 'common',
         );
 
         $postTypes = multiselect(
             label: 'Select the supported post types',
-            options: collect(
+            options: $this->collect(
                 get_post_types(['public' => true])
             )->mapWithKeys(fn ($postType) => [$postType => Str::headline($postType)])->all(),
             hint: 'Leave empty to support all post types.',
         );
 
-        $postTypes = collect($postTypes)
+        $postTypes = $this->collect($postTypes)
             ->map(fn ($postType) => sprintf("'%s'", $postType))
             ->join(', ');
 
@@ -116,12 +116,12 @@ class BlockMakeCommand extends MakeCommand
      */
     protected function buildSupports(array $selected): string
     {
-        return collect($this->supports)->map(function ($value, $key) use ($selected) {
+        return $this->collect($this->supports)->map(function ($value, $key) use ($selected) {
             if (is_int($key)) {
                 return sprintf("'%s' => %s,", $value, in_array($value, $selected) ? 'true' : 'false');
             }
 
-            $options = collect($value)
+            $options = $this->collect($value)
                 ->map(fn ($option) => sprintf(
                     "%s'%s' => %s,",
                     Str::repeat(' ', 12),
@@ -139,9 +139,9 @@ class BlockMakeCommand extends MakeCommand
      */
     protected function getSupports(): array
     {
-        return collect($this->supports)
+        return $this->collect($this->supports)
             ->mapWithKeys(fn ($value, $key) => is_array($value)
-                ? collect($value)->mapWithKeys(fn ($option) => [$option => Str::of($option)->finish(" {$key}")->headline()->toString()])->all()
+                ? $this->collect($value)->mapWithKeys(fn ($option) => [$option => Str::of($option)->finish(" {$key}")->headline()->toString()])->all()
                 : [$value => Str::headline($value)]
             )->all();
     }

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -4,9 +4,12 @@ namespace Log1x\AcfComposer\Console;
 
 use Illuminate\Console\Command;
 use Log1x\AcfComposer\AcfComposer;
+use Log1x\AcfComposer\Concerns\HasCollection;
 
 class CacheCommand extends Command
 {
+    use HasCollection;
+
     /**
      * The name and signature of the console command.
      *
@@ -54,7 +57,7 @@ class CacheCommand extends Command
             return $this->components->info("<fg=blue>ACF Composer</> is currently {$status}.");
         }
 
-        $composers = collect(
+        $composers = $this->collect(
             $this->composer->composers()
         )->flatten();
 

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -4,10 +4,13 @@ namespace Log1x\AcfComposer\Console;
 
 use Exception;
 use Illuminate\Support\Str;
+use Log1x\AcfComposer\Concerns\HasCollection;
 use Roots\Acorn\Console\Commands\GeneratorCommand;
 
 class MakeCommand extends GeneratorCommand
 {
+    use HasCollection;
+
     /**
      * The view stub used when generated.
      *
@@ -168,7 +171,7 @@ class MakeCommand extends GeneratorCommand
      */
     protected function getType()
     {
-        return collect(explode('\\', $this->type))->map(function ($value) {
+        return $this->collect(explode('\\', $this->type))->map(function ($value) {
             return Str::singular(Str::slug($value));
         })->implode(' ');
     }
@@ -254,7 +257,7 @@ class MakeCommand extends GeneratorCommand
      */
     protected function shortenPath($path, $index = 3)
     {
-        return collect(
+        return $this->collect(
             explode('/', $path)
         )->slice(-$index, $index)->implode('/');
     }

--- a/src/Console/StubPublishCommand.php
+++ b/src/Console/StubPublishCommand.php
@@ -3,10 +3,13 @@
 namespace Log1x\AcfComposer\Console;
 
 use Illuminate\Filesystem\Filesystem;
+use Log1x\AcfComposer\Concerns\HasCollection;
 use Roots\Acorn\Console\Commands\Command;
 
 class StubPublishCommand extends Command
 {
+    use HasCollection;
+
     /**
      * The name and signature of the console command.
      *
@@ -53,7 +56,7 @@ class StubPublishCommand extends Command
             (new Filesystem)->makeDirectory($stubsPath.'/views', 0755, true);
         }
 
-        $files = collect($this->stubs)
+        $files = $this->collect($this->stubs)
             ->mapWithKeys(function ($stub) use ($stubsPath) {
                 return [__DIR__.'/stubs/'.$stub => $stubsPath.'/'.$stub];
             })->toArray();

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -5,9 +5,12 @@ namespace Log1x\AcfComposer\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use Log1x\AcfComposer\AcfComposer;
+use Log1x\AcfComposer\Concerns\HasCollection;
 
 class UpgradeCommand extends Command
 {
+    use HasCollection;
+
     /**
      * The name and signature of the console command.
      *
@@ -52,7 +55,7 @@ class UpgradeCommand extends Command
 
         $this->components->info('Checking for outdated <fg=blue>ACF Composer</> classes...');
 
-        $classes = collect($this->composer->paths())->flatMap(fn ($classes, $path) => collect($classes)
+        $classes = $this->collect($this->composer->paths())->flatMap(fn ($classes, $path) => $this->collect($classes)
             ->map(fn ($class) => Str::of($class)->replace('\\', '/')->after('/')->start($path.'/')->finish('.php')->toString())
             ->all()
         )

--- a/src/Console/UsageCommand.php
+++ b/src/Console/UsageCommand.php
@@ -5,12 +5,15 @@ namespace Log1x\AcfComposer\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Log1x\AcfComposer\Concerns\HasCollection;
 
 use function Laravel\Prompts\search;
 use function Laravel\Prompts\table;
 
 class UsageCommand extends Command
 {
+    use HasCollection;
+
     /**
      * The name and signature of the console command.
      *
@@ -54,7 +57,7 @@ class UsageCommand extends Command
             return $this->components->error("The field type [<fg=red>{$field}</>] could not be found.");
         }
 
-        $options = collect([
+        $options = $this->collect([
             ...$type->defaults ?? [],
             ...$type->supports ?? [],
         ])->except('escaping_html');
@@ -74,7 +77,7 @@ class UsageCommand extends Command
 
         $native = method_exists('Log1x\AcfComposer\Builder', $method) ? $method : null;
 
-        $options = collect($options)->map(fn ($value) => match (true) {
+        $options = $this->collect($options)->map(fn ($value) => match (true) {
             is_string($value) => "'{$value}'",
             is_array($value) => '[]',
             is_bool($value) => $value ? 'true' : 'false',
@@ -88,7 +91,7 @@ class UsageCommand extends Command
             'native' => $native,
         ]);
 
-        $usage = collect(explode("\n", $usage))
+        $usage = $this->collect(explode("\n", $usage))
             ->map(fn ($line) => rtrim(" {$line}"))
             ->filter()
             ->implode("\n");
@@ -149,7 +152,7 @@ class UsageCommand extends Command
      */
     protected function types(): Collection
     {
-        return collect(
+        return $this->collect(
             acf_get_field_types()
         )->map(function ($type) {
             if (Str::startsWith($type->doc_url, 'https://www.advancedcustomfields.com')) {

--- a/src/Widget.php
+++ b/src/Widget.php
@@ -71,7 +71,7 @@ abstract class Widget extends Composer implements WidgetContract
         }
 
         $this->register(function () {
-            $this->widget = (object) collect(
+            $this->widget = (object) $this->collect(
                 Arr::get($GLOBALS, 'wp_registered_widgets')
             )->filter(fn ($value) => $value['name'] === $this->name)->pop();
         });
@@ -128,7 +128,7 @@ abstract class Widget extends Composer implements WidgetContract
                 echo Arr::get($args, 'before_widget');
 
                 if (! empty($this->composer->title())) {
-                    echo collect([
+                    echo $this->collect([
                         Arr::get($args, 'before_title'),
                         $this->composer->title(),
                         Arr::get($args, 'after_title'),


### PR DESCRIPTION
## Description
Add insulation from projects that aren't correctly namespaced that hijack the illuminate collect() function. 
This PR uses the HasCollection trait system used on https://github.com/Log1x/poet/blob/master/src/Concerns/HasCollection.php to insulate the collect() helper function.

## Issues addressed
Compatibility issue with LearnDash plugin #303 