### PR TITLE
✨ Add native support for block spacing

### DIFF
--- a/src/Console/BlockMakeCommand.php
+++ b/src/Console/BlockMakeCommand.php
@@ -53,6 +53,7 @@ class BlockMakeCommand extends MakeCommand
         'multiple',
         'jsx',
         'color' => ['background', 'text', 'gradients'],
+        'spacing' => ['padding', 'margin'],
     ];
 
     /**

--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -92,6 +92,16 @@ class DummyClass extends Block
     public $align_content = '';
 
     /**
+     * The default block spacing.
+     *
+     * @var array
+     */
+    public $spacing = [
+        'padding' => null,
+        'margin' => null,
+    ];
+
+    /**
      * The supported block features.
      *
      * @var array


### PR DESCRIPTION
This adds proper support for block spacing and improves block attribute consistency when uncached vs cached.

`acf_register_block_type` doesn't support custom attributes for blocks registered using PHP so ACF Composer now has it's own `registerBlockType` method to allow for configuring defaults on things like spacing when not cached as `block.json`.

Ref: #302 #310