### PR TITLE
Enqueue block assets with 'enqueue_block_assets' action

### DIFF
--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -193,13 +193,17 @@ class AcfComposer
      */
     protected function handleBlocks(): void
     {
-        add_action('enqueue_block_assets', function () {
+        add_action('acf/init', function () {
             foreach ($this->composers() as $composers) {
                 foreach ($composers as $composer) {
-                    method_exists($composer, 'assets') && $composer->assets([]);
+                    if (! is_a($composer, Block::class)) {
+                        continue;
+                    }
+
+                    method_exists($composer, 'assets') && $composer->assets();
                 }
             }
-        });
+        }, 101);
 
         add_action('acf_block_render_template', function ($block, $content, $is_preview, $post_id, $wp_block, $context) {
             if (! class_exists($composer = $block['render_template'] ?? '')) {

--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -193,17 +193,19 @@ class AcfComposer
      */
     protected function handleBlocks(): void
     {
-        add_action('acf/init', function () {
+        add_action('enqueue_block_assets', function () {
             foreach ($this->composers() as $composers) {
                 foreach ($composers as $composer) {
                     if (! is_a($composer, Block::class)) {
                         continue;
                     }
 
-                    method_exists($composer, 'assets') && $composer->assets();
+                    if (is_admin() || has_block($composer->namespace)) {
+                        method_exists($composer, 'assets') && $composer->assets($composer->block);
+                    }
                 }
             }
-        }, 101);
+        });
 
         add_action('acf_block_render_template', function ($block, $content, $is_preview, $post_id, $wp_block, $context) {
             if (! class_exists($composer = $block['render_template'] ?? '')) {

--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -193,6 +193,14 @@ class AcfComposer
      */
     protected function handleBlocks(): void
     {
+        add_action('enqueue_block_assets', function () {
+            foreach ($this->composers() as $composers) {
+                foreach ($composers as $composer) {
+                    method_exists($composer, 'assets') && $composer->assets([]);
+                }
+            }
+        });
+
         add_action('acf_block_render_template', function ($block, $content, $is_preview, $post_id, $wp_block, $context) {
             if (! class_exists($composer = $block['render_template'] ?? '')) {
                 return;
@@ -203,8 +211,6 @@ class AcfComposer
             }
 
             add_filter('acf/blocks/template_not_found_message', fn () => '');
-
-            method_exists($composer, 'assets') && $composer->assets($block);
 
             echo $composer->render($block, $content, $is_preview, $post_id, $wp_block, $context);
         }, 9, 6);

--- a/src/Block.php
+++ b/src/Block.php
@@ -443,13 +443,41 @@ abstract class Block extends Composer implements BlockContract
      */
     public function getClasses(): string
     {
-        $supports = $this->getHtmlAttributes();
+        $classes = $this->collect([
+            'slug' => Str::of($this->slug)->slug()->start('wp-block-')->toString(),
 
-        return str_replace(
-            acf_slugify($this->namespace),
-            $this->slug,
-            $supports['class'] ?? "wp-block-{$this->slug}"
-        );
+            'className' => $this->block->className ?? null,
+
+            'align' => ! empty($this->block->align)
+                ? Str::start($this->block->align, 'align')
+                : null,
+
+            'backgroundColor' => ! empty($this->block->backgroundColor)
+                ? sprintf('has-background has-%s-background-color', $this->block->backgroundColor)
+                : null,
+
+            'textColor' => ! empty($this->block->textColor)
+                ? sprintf('has-%s-color', $this->block->textColor)
+                : null,
+
+            'gradient' => ! empty($this->block->gradient)
+                ? sprintf('has-%s-gradient-background', $this->block->gradient)
+                : null,
+        ]);
+
+        if ($alignText = $this->block->alignText ?? $this->block->align_text ?? null) {
+            $classes->add(Str::start($alignText, 'align-text-'));
+        }
+
+        if ($alignContent = $this->block->alignContent ?? $this->block->align_content ?? null) {
+            $classes->add(Str::start($alignContent, 'is-position-'));
+        }
+
+        if ($this->block->fullHeight ?? $this->block->full_height ?? null) {
+            $classes->add('full-height');
+        }
+
+        return $classes->filter()->implode(' ');
     }
 
     /**
@@ -601,7 +629,6 @@ abstract class Block extends Composer implements BlockContract
             'alignContent' => $this->align_content,
             'styles' => $this->getStyles(),
             'supports' => $this->supports,
-            'enqueue_assets' => fn ($block) => method_exists($this, 'assets') ? $this->assets($block) : null,
             'textdomain' => $this->getTextDomain(),
             'acf_block_version' => $this->blockVersion,
             'api_version' => 2,
@@ -671,7 +698,6 @@ abstract class Block extends Composer implements BlockContract
                 'align',
                 'alignContent',
                 'alignText',
-                'enqueue_assets',
                 'mode',
                 'post_types',
                 'render_callback',
@@ -736,7 +762,7 @@ abstract class Block extends Composer implements BlockContract
      *
      * @return void
      *
-     * @deprecated Use `assets($block)` instead.
+     * @deprecated Use `assets()` instead.
      */
     public function enqueue()
     {

--- a/src/Block.php
+++ b/src/Block.php
@@ -443,41 +443,13 @@ abstract class Block extends Composer implements BlockContract
      */
     public function getClasses(): string
     {
-        $classes = $this->collect([
-            'slug' => Str::of($this->slug)->slug()->start('wp-block-')->toString(),
+        $supports = $this->getHtmlAttributes();
 
-            'className' => $this->block->className ?? null,
-
-            'align' => ! empty($this->block->align)
-                ? Str::start($this->block->align, 'align')
-                : null,
-
-            'backgroundColor' => ! empty($this->block->backgroundColor)
-                ? sprintf('has-background has-%s-background-color', $this->block->backgroundColor)
-                : null,
-
-            'textColor' => ! empty($this->block->textColor)
-                ? sprintf('has-%s-color', $this->block->textColor)
-                : null,
-
-            'gradient' => ! empty($this->block->gradient)
-                ? sprintf('has-%s-gradient-background', $this->block->gradient)
-                : null,
-        ]);
-
-        if ($alignText = $this->block->alignText ?? $this->block->align_text ?? null) {
-            $classes->add(Str::start($alignText, 'align-text-'));
-        }
-
-        if ($alignContent = $this->block->alignContent ?? $this->block->align_content ?? null) {
-            $classes->add(Str::start($alignContent, 'is-position-'));
-        }
-
-        if ($this->block->fullHeight ?? $this->block->full_height ?? null) {
-            $classes->add('full-height');
-        }
-
-        return $classes->filter()->implode(' ');
+        return str_replace(
+            acf_slugify($this->namespace),
+            $this->slug,
+            $supports['class'] ?? "wp-block-{$this->slug}"
+        );
     }
 
     /**

--- a/src/Block.php
+++ b/src/Block.php
@@ -734,7 +734,7 @@ abstract class Block extends Composer implements BlockContract
      *
      * @return void
      *
-     * @deprecated Use `assets()` instead.
+     * @deprecated Use `assets($block)` instead.
      */
     public function enqueue()
     {

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -49,6 +49,7 @@ class UpgradeCommand extends Command
             'public function enqueue($block)' => 'public function assets(array $block): void',
             'public function enqueue($block = [])' => 'public function assets(array $block): void',
             'public function enqueue()' => 'public function assets(array $block): void',
+            'public function enqueue(array $block): void' => 'public function assets(): void',
             '/->addFields\(\$this->get\((.*?)\)\)/' => fn ($match) => "->addPartial({$match[1]})",
             '/->addLayout\(\$this->get\((.*?)\)\)/' => fn ($match) => "->addLayout({$match[1]})",
         ];

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -49,8 +49,6 @@ class UpgradeCommand extends Command
             'public function enqueue($block)' => 'public function assets(array $block): void',
             'public function enqueue($block = [])' => 'public function assets(array $block): void',
             'public function enqueue()' => 'public function assets(array $block): void',
-            'public function enqueue(array $block): void' => 'public function assets(): void',
-            'public function assets(array $block): void' => 'public function assets(): void',
             '/->addFields\(\$this->get\((.*?)\)\)/' => fn ($match) => "->addPartial({$match[1]})",
             '/->addLayout\(\$this->get\((.*?)\)\)/' => fn ($match) => "->addLayout({$match[1]})",
         ];

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -50,6 +50,7 @@ class UpgradeCommand extends Command
             'public function enqueue($block = [])' => 'public function assets(array $block): void',
             'public function enqueue()' => 'public function assets(array $block): void',
             'public function enqueue(array $block): void' => 'public function assets(): void',
+            'public function assets(array $block): void' => 'public function assets(): void',
             '/->addFields\(\$this->get\((.*?)\)\)/' => fn ($match) => "->addPartial({$match[1]})",
             '/->addLayout\(\$this->get\((.*?)\)\)/' => fn ($match) => "->addLayout({$match[1]})",
         ];

--- a/src/Console/stubs/block.localized.stub
+++ b/src/Console/stubs/block.localized.stub
@@ -175,9 +175,9 @@ class DummyClass extends Block
     }
 
     /**
-     * Assets enqueued when rendering the block.
+     * Assets enqueued with 'enqueue_block_assets' when rendering the block.
      */
-    public function assets(array $block): void
+    public function assets(): void
     {
         //
     }

--- a/src/Console/stubs/block.localized.stub
+++ b/src/Console/stubs/block.localized.stub
@@ -176,8 +176,10 @@ class DummyClass extends Block
 
     /**
      * Assets enqueued with 'enqueue_block_assets' when rendering the block.
+     *
+     * @link https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/#editor-content-scripts-and-styles
      */
-    public function assets(): void
+    public function assets(array $block): void
     {
         //
     }

--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -176,9 +176,9 @@ class DummyClass extends Block
     }
 
     /**
-     * Assets enqueued when rendering the block.
+     * Assets enqueued with 'enqueue_block_assets' when rendering the block.
      */
-    public function assets(array $block): void
+    public function assets(): void
     {
         //
     }

--- a/src/Console/stubs/block.stub
+++ b/src/Console/stubs/block.stub
@@ -177,8 +177,10 @@ class DummyClass extends Block
 
     /**
      * Assets enqueued with 'enqueue_block_assets' when rendering the block.
+     *
+     * @link https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/#editor-content-scripts-and-styles
      */
-    public function assets(): void
+    public function assets(array $block): void
     {
         //
     }


### PR DESCRIPTION
Refactor `assets()` call to support (a) cached blocks & (b) the iframed Block Editor & Site Editor.

For more detailse see https://github.com/Log1x/acf-composer/issues/304.