### PR TITLE
✨ Add view attribute bag support to blocks

### DIFF
--- a/resources/views/alpine-support.blade.php
+++ b/resources/views/alpine-support.blade.php
@@ -1,3 +1,3 @@
 <script type="text/javascript">
-  acf.addFilter('acf_blocks_parse_node_attr', (current, node) => node.name.startsWith('x-') ? node : current);
+  acf.addFilter('acf_blocks_parse_node_attr', (current, node) => (node.name.startsWith('x-') || node.name.startsWith('@')) ? node : current);
 </script>

--- a/resources/views/block-editor-filters.blade.php
+++ b/resources/views/block-editor-filters.blade.php
@@ -1,0 +1,27 @@
+@verbatim
+  wp.hooks.addFilter(
+    'blocks.getBlockDefaultClassName',
+    'acf-composer/block-slug-classname',
+    (className, blockName) => {
+        if (! blockName.startsWith('acf/')) {
+            return className;
+        }
+
+        const list = (className || '').split(/\\s+/);
+
+        const classes = list.reduce((acc, current) => {
+            acc.push(current);
+
+            if (current.startsWith('wp-block-acf-')) {
+                acc.push(
+                    current.replace('wp-block-acf-', 'wp-block-')
+                );
+            }
+
+            return acc;
+        }, []);
+
+        return classes.join(' ');
+    }
+  );
+@endverbatim

--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -207,6 +207,10 @@ class AcfComposer
             }
         });
 
+        add_action('enqueue_block_editor_assets', function () {
+            wp_add_inline_script('wp-blocks', view('acf-composer::block-editor-filters')->render());
+        });
+
         add_action('acf_block_render_template', function ($block, $content, $is_preview, $post_id, $wp_block, $context) {
             if (! class_exists($composer = $block['render_template'] ?? '')) {
                 return;

--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -201,7 +201,7 @@ class AcfComposer
                     }
 
                     if (is_admin() || has_block($composer->namespace)) {
-                        method_exists($composer, 'assets') && $composer->assets($composer->block);
+                        method_exists($composer, 'assets') && $composer->assets((array) $composer->block ?? []);
                     }
                 }
             }

--- a/src/Block.php
+++ b/src/Block.php
@@ -474,7 +474,7 @@ abstract class Block extends Composer implements BlockContract
         return str_replace(
             acf_slugify($this->namespace),
             $this->slug,
-            $supports['class'] ?? "wp-block-{$this->slug}"
+            $supports['class'] ?? ''
         );
     }
 

--- a/src/Block.php
+++ b/src/Block.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\View\ComponentAttributeBag;
 use Log1x\AcfComposer\Concerns\InteractsWithBlade;
 use Log1x\AcfComposer\Contracts\Block as BlockContract;
 use WP_Block_Supports;
@@ -375,6 +376,30 @@ abstract class Block extends Composer implements BlockContract
     }
 
     /**
+     * Retrieve the block supports.
+     */
+    public function getSupports(): array
+    {
+        $supports = $this->collect($this->supports)
+            ->mapWithKeys(fn ($value, $key) => [Str::camel($key) => $value])
+            ->merge($this->supports);
+
+        $typography = $supports->get('typography', []);
+
+        if ($supports->has('alignText')) {
+            $typography['textAlign'] = $supports->get('alignText');
+
+            $supports->forget(['alignText', 'align_text']);
+        }
+
+        if ($typography) {
+            $supports->put('typography', $typography);
+        }
+
+        return $supports->all();
+    }
+
+    /**
      * Retrieve the block support attributes.
      */
     public function getSupportAttributes(): array
@@ -388,13 +413,6 @@ abstract class Block extends Composer implements BlockContract
             ];
         }
 
-        if ($this->align_text) {
-            $attributes['alignText'] = [
-                'type' => 'string',
-                'default' => $this->align_text,
-            ];
-        }
-
         if ($this->align_content) {
             $attributes['alignContent'] = [
                 'type' => 'string',
@@ -402,14 +420,22 @@ abstract class Block extends Composer implements BlockContract
             ];
         }
 
+        $styles = [];
+
+        if ($this->align_text) {
+            $styles['typography']['textAlign'] = $this->align_text;
+        }
+
         $spacing = array_filter($this->spacing);
 
         if ($spacing) {
+            $styles['spacing'] = $spacing;
+        }
+
+        if ($styles) {
             $attributes['style'] = [
                 'type' => 'object',
-                'default' => [
-                    'spacing' => $spacing,
-                ],
+                'default' => $styles,
             ];
         }
 
@@ -579,13 +605,6 @@ abstract class Block extends Composer implements BlockContract
             return $this->settings;
         }
 
-        if ($this->supports) {
-            $this->supports = $this->collect($this->supports)
-                ->mapWithKeys(fn ($value, $key) => [Str::camel($key) => $value])
-                ->merge($this->supports)
-                ->all();
-        }
-
         $settings = Collection::make([
             'name' => $this->slug,
             'title' => $this->getName(),
@@ -600,7 +619,7 @@ abstract class Block extends Composer implements BlockContract
             'alignText' => $this->align_text ?? $this->align,
             'alignContent' => $this->align_content,
             'styles' => $this->getStyles(),
-            'supports' => $this->supports,
+            'supports' => $this->getSupports(),
             'textdomain' => $this->getTextDomain(),
             'acf_block_version' => $this->blockVersion,
             'api_version' => 2,
@@ -726,7 +745,15 @@ abstract class Block extends Composer implements BlockContract
         $this->style = $this->getStyle();
         $this->inlineStyle = $this->getInlineStyle();
 
-        return $this->view($this->view, ['block' => $this]);
+        $attributes = (new ComponentAttributeBag)
+            ->class($this->classes)
+            ->style($this->inlineStyle)
+            ->filter(fn ($value) => filled($value) && $value !== ';');
+
+        return $this->view($this->view, [
+            'block' => $this,
+            'attributes' => $attributes,
+        ]);
     }
 
     /**

--- a/src/Console/stubs/views/block.stub
+++ b/src/Console/stubs/views/block.stub
@@ -1,4 +1,4 @@
-<div class="{{ $block->classes }}" style="{{ $block->inlineStyle }}">
+<div {{ $attributes }}>
   @if ($items)
     <ul>
       @foreach ($items as $item)


### PR DESCRIPTION
- 🩹 Ensure `assets()` receives an array
- 🩹 Fix typography attribute compatibility (Fixes #316)
- ✨ Add view `$attribute` bag support to blocks 
- 💄 Update the block view stub to use the attribute bag
- 🧑‍💻 Improve Alpine support with `@` in blocks while in the editor
- 🧑‍💻 Add the `wp-block-` classname without `acf` namespace to the block list containers