### PR TITLE
Improve enqueue block assets with 'enqueue_block_assets' action

### DIFF
--- a/src/AcfComposer.php
+++ b/src/AcfComposer.php
@@ -193,19 +193,19 @@ class AcfComposer
      */
     protected function handleBlocks(): void
     {
-        add_action('enqueue_block_assets', function () {
-            foreach ($this->composers() as $composers) {
-                foreach ($composers as $composer) {
-                    if (! is_a($composer, Block::class)) {
-                        continue;
-                    }
+        if (is_admin()) {
+            add_action('enqueue_block_assets', function () {
+                foreach ($this->composers() as $composers) {
+                    foreach ($composers as $composer) {
+                        if (! is_a($composer, Block::class)) {
+                            continue;
+                        }
 
-                    if (is_admin() || has_block($composer->namespace)) {
                         method_exists($composer, 'assets') && $composer->assets((array) $composer->block ?? []);
                     }
                 }
-            }
-        });
+            });
+        }
 
         add_action('enqueue_block_editor_assets', function () {
             wp_add_inline_script('wp-blocks', view('acf-composer::block-editor-filters')->render());

--- a/src/Block.php
+++ b/src/Block.php
@@ -750,6 +750,12 @@ abstract class Block extends Composer implements BlockContract
             ->style($this->inlineStyle)
             ->filter(fn ($value) => filled($value) && $value !== ';');
 
+        if (!is_admin() && method_exists($this, 'assets')) {
+            add_action('enqueue_block_assets', function () {
+                $this->assets((array) $this->block ?? []);
+            });
+        }
+
         return $this->view($this->view, [
             'block' => $this,
             'attributes' => $attributes,

--- a/src/Block.php
+++ b/src/Block.php
@@ -750,7 +750,7 @@ abstract class Block extends Composer implements BlockContract
             ->style($this->inlineStyle)
             ->filter(fn ($value) => filled($value) && $value !== ';');
 
-        if (!is_admin() && method_exists($this, 'assets')) {
+        if (! is_admin() && method_exists($this, 'assets')) {
             add_action('enqueue_block_assets', function () {
                 $this->assets((array) $this->block ?? []);
             });


### PR DESCRIPTION
This improves the [previous solution](https://github.com/Log1x/acf-composer/pull/315) by

- Supporting blocks in synchronised patterns
- Loading assets for blocks on frontend when rendering

This has been tested with cached/uncached blocks in iframed/non-iframed editors.