### PR TITLE
🩹 fix: Add support for legacy blocks

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -397,18 +397,6 @@ abstract class Block extends Composer implements BlockContract
             ->mapWithKeys(fn ($value, $key) => [Str::camel($key) => $value])
             ->merge($this->supports);
 
-        $typography = $supports->get('typography', []);
-
-        if ($supports->has('alignText')) {
-            $typography['textAlign'] = $supports->get('alignText');
-
-            $supports->forget(['alignText', 'align_text']);
-        }
-
-        if ($typography) {
-            $supports->put('typography', $typography);
-        }
-
         return $supports->all();
     }
 
@@ -434,10 +422,6 @@ abstract class Block extends Composer implements BlockContract
         }
 
         $styles = [];
-
-        if ($this->align_text) {
-            $styles['typography']['textAlign'] = $this->align_text;
-        }
 
         $spacing = array_filter($this->spacing);
 
@@ -488,6 +472,10 @@ abstract class Block extends Composer implements BlockContract
 
         if ($alignContent = $this->block->alignContent ?? $this->block->align_content ?? null) {
             $class = "{$class} is-position-{$alignContent}";
+        }
+
+        if ($alignText = $this->block->alignText ?? $this->block->align_text ?? null) {
+            $class = "{$class} align-text-{$alignText}";
         }
 
         if ($this->block->fullHeight ?? $this->block->full_height ?? null) {

--- a/src/Console/BlockMakeCommand.php
+++ b/src/Console/BlockMakeCommand.php
@@ -45,7 +45,6 @@ class BlockMakeCommand extends MakeCommand
      */
     protected array $supports = [
         'align',
-        'align_text',
         'align_content',
         'full_height',
         'anchor',
@@ -54,6 +53,7 @@ class BlockMakeCommand extends MakeCommand
         'jsx',
         'color' => ['background', 'text', 'gradients'],
         'spacing' => ['padding', 'margin'],
+        'typography' => ['textAlign'],
     ];
 
     /**


### PR DESCRIPTION
Don't move `supports['align_text']` to `supports['typography']['textAlign']` and re-add `align-text-*` class to legacy blocks. New blocks now have text alignment in `supports['typography']['textAlign']`.