### PR TITLE
Fix crash when trying to publish stubs using Acorn

### DIFF
--- a/src/Console/StubPublishCommand.php
+++ b/src/Console/StubPublishCommand.php
@@ -30,7 +30,7 @@ class StubPublishCommand extends Command
      * @var array
      */
     protected $stubs = [
-        'block.construct.stub',
+        'block.localized.stub',
         'block.stub',
         'field.stub',
         'options.full.stub',


### PR DESCRIPTION
### Issue
Running `wp acorn acf:stubs` generates this error:
```
In StubPublishCommand.php line 66:
file_get_contents(/app/web/app/themes/sage/vendor/log1x/acf-composer/src/Console/stubs/block.construct.stub): Failed
   to open stream: No such file or directory
```

### Fix
Replace `block.construct.stub` with `block.localized.stub` in the available stubs array to match the files.