### PR TITLE
Fix block type registration in WordPress 6.8

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -271,7 +271,6 @@ abstract class Block extends Composer implements BlockContract
                 'category' => $this->category,
                 'icon' => $this->icon,
                 'keywords' => $this->keywords,
-                'parent' => $this->parent ?: [],
                 'post_types' => $this->post_types,
                 'mode' => $this->mode,
                 'align' => $this->align,
@@ -293,6 +292,10 @@ abstract class Block extends Composer implements BlockContract
                     echo $this->render($block, $content, $preview, $post_id, $wp_block, $context);
                 },
             ];
+
+            if (filled($this->parent)) {
+                $settings = Arr::add($settings, 'parent', $this->parent);
+            }
 
             if ($this->example !== false) {
                 $settings = Arr::add($settings, 'example', [


### PR DESCRIPTION
### Issue
https://github.com/Log1x/acf-composer/issues/340#issuecomment-2890124534

### Fix
Only add `parent` to the settings array if its value is not empty.