### PR TITLE
Add support for block anchor

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -509,6 +509,7 @@ abstract class Block extends Composer implements BlockContract
         return (new ComponentAttributeBag)
             ->class($this->getClasses())
             ->style($this->getInlineStyle())
+            ->merge(['id' => $this->block->anchor ?? null])
             ->filter(fn ($value) => filled($value) && $value !== ';');
     }
 


### PR DESCRIPTION
- Added support for block anchor
- The `id` attribute can be deleted or changed by implementing the `getComponentAttributeBag()` method in the child class