### PR TITLE
Allow localization of option page's name and title

### DIFF
--- a/src/Console/OptionsMakeCommand.php
+++ b/src/Console/OptionsMakeCommand.php
@@ -11,6 +11,7 @@ class OptionsMakeCommand extends MakeCommand
      */
     protected $signature = 'acf:options {name* : The name of the options page}
                             {--full : Scaffold an options page that contains the complete configuration.}
+                            {--localize : Localize the options page name and title}
                             {--force : Overwrite any existing files}';
 
     /**
@@ -43,6 +44,10 @@ class OptionsMakeCommand extends MakeCommand
     {
         if ($this->option('full')) {
             return $this->resolveStub('options.full');
+        }
+
+        if ($this->option('localize')) {
+            return $this->resolveStub('options.localized');
         }
 
         return $this->resolveStub('options');

--- a/src/Console/StubPublishCommand.php
+++ b/src/Console/StubPublishCommand.php
@@ -33,6 +33,7 @@ class StubPublishCommand extends Command
         'block.localized.stub',
         'block.stub',
         'field.stub',
+        'options.localized.stub',
         'options.full.stub',
         'options.stub',
         'partial.stub',

--- a/src/Console/stubs/options.full.stub
+++ b/src/Console/stubs/options.full.stub
@@ -40,7 +40,7 @@ class DummyClass extends Field
      *
      * @var int
      */
-    public $position = PHP_INT_MAX;
+    public $position = PHP_INT_MAX; // TODO: change to another value if you have multiple option pages.
 
     /**
      * The option page visibility in the admin menu.

--- a/src/Console/stubs/options.full.stub
+++ b/src/Console/stubs/options.full.stub
@@ -40,7 +40,7 @@ class DummyClass extends Field
      *
      * @var int
      */
-    public $position = PHP_INT_MAX; // TODO: change to another value if you have multiple option pages.
+    public $position = PHP_INT_MAX;
 
     /**
      * The option page visibility in the admin menu.

--- a/src/Console/stubs/options.localized.stub
+++ b/src/Console/stubs/options.localized.stub
@@ -1,0 +1,40 @@
+<?php
+
+namespace DummyNamespace;
+
+use Log1x\AcfComposer\Builder;
+use Log1x\AcfComposer\Options as Field;
+
+class DummyClass extends Field
+{
+    /**
+     * Retrieve the option page menu name.
+     */
+    public function getName(): string
+    {
+        return __('DummyTitle', 'sage');
+    }
+
+    /**
+     * Retrieve the option page document title.
+     */
+    public function getTitle(): string
+    {
+        return __('DummyTitle', 'sage');
+    }
+
+    /**
+     * The option page field group.
+     */
+    public function fields(): array
+    {
+        $fields = Builder::make('DummySnake');
+
+        $fields
+            ->addRepeater('items')
+                ->addText('item')
+            ->endRepeater();
+
+        return $fields->build();
+    }
+}

--- a/src/Console/stubs/options.localized.stub
+++ b/src/Console/stubs/options.localized.stub
@@ -24,6 +24,13 @@ class DummyClass extends Field
     }
 
     /**
+     * The option page menu position.
+     *
+     * @var int
+     */
+    public $position = PHP_INT_MAX; // TODO: change to another value if you have multiple option pages.
+
+    /**
      * The option page field group.
      */
     public function fields(): array

--- a/src/Console/stubs/options.localized.stub
+++ b/src/Console/stubs/options.localized.stub
@@ -28,7 +28,7 @@ class DummyClass extends Field
      *
      * @var int
      */
-    public $position = PHP_INT_MAX; // TODO: change to another value if you have multiple option pages.
+    public $position = PHP_INT_MAX;
 
     /**
      * The option page field group.

--- a/src/Console/stubs/options.stub
+++ b/src/Console/stubs/options.stub
@@ -22,6 +22,13 @@ class DummyClass extends Field
     public $title = 'DummyTitle | Options';
 
     /**
+     * The option page menu position.
+     *
+     * @var int
+     */
+    public $position = PHP_INT_MAX; // TODO: change to another value if you have multiple option pages.
+
+    /**
      * The option page field group.
      */
     public function fields(): array

--- a/src/Console/stubs/options.stub
+++ b/src/Console/stubs/options.stub
@@ -26,7 +26,7 @@ class DummyClass extends Field
      *
      * @var int
      */
-    public $position = PHP_INT_MAX; // TODO: change to another value if you have multiple option pages.
+    public $position = PHP_INT_MAX;
 
     /**
      * The option page field group.

--- a/src/Options.php
+++ b/src/Options.php
@@ -92,6 +92,22 @@ abstract class Options extends Composer
     public $settings = [];
 
     /**
+     * Retrieve the option page menu name.
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Retrieve the option page document title.
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
      * Localized text displayed on the submit button.
      *
      * @return string
@@ -118,16 +134,16 @@ abstract class Options extends Composer
      */
     public function compose()
     {
-        if (empty($this->name)) {
-            return;
-        }
+        if (blank($this->getName())) {
+            return null;
+        }            
 
         if (empty($this->slug)) {
-            $this->slug = Str::slug($this->name);
+            $this->slug = Str::slug($this->getName());
         }
 
-        if (empty($this->title)) {
-            $this->title = $this->name;
+        if (blank($this->getTitle())) {
+            $this->title = $this->getName();
         }
 
         if (! Arr::has($this->fields, 'location.0.0')) {
@@ -145,9 +161,9 @@ abstract class Options extends Composer
 
             acf_add_options_page(
                 array_merge([
-                    'menu_title' => $this->name,
+                    'menu_title' => $this->getName(),
                     'menu_slug' => $this->slug,
-                    'page_title' => $this->title,
+                    'page_title' => $this->getTitle(),
                     'capability' => $this->capability,
                     'position' => $this->position,
                     'parent_slug' => $this->parent,

--- a/src/Options.php
+++ b/src/Options.php
@@ -136,7 +136,7 @@ abstract class Options extends Composer
     {
         if (blank($this->getName())) {
             return null;
-        }            
+        }
 
         if (empty($this->slug)) {
             $this->slug = Str::slug($this->getName());


### PR DESCRIPTION
First of all: Incredible work, I use the package a lot! 🤩

I've noticed that the option page is not localizable yet, so I've just added the necessary functionality. Also, I've included the `$position` in the `options.stub` and added a hint for developers to change the `$position`, otherwise only one (or none) will be displayed.

Please also test the code and I'd be happy if the change gets merged. 