### PR TITLE
Add inline editing for blocks (ACF 6.7+)

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -735,11 +735,10 @@ abstract class Block extends Composer implements BlockContract
         $settings = $this->settings()
             ->put('name', $this->namespace)
             ->put('apiVersion', $this->getApiVersion())
-            ->put('acf', $acf)
             ->put('usesContext', $this->uses_context)
             ->put('providesContext', $this->provides_context)
             ->put('acf', [
-                'blockVersion' => $this->blockVersion,
+                'blockVersion' => $this->getBlockVersion(),
                 'mode' => $this->mode,
                 'postTypes' => $this->post_types,
                 'renderTemplate' => $this::class,

--- a/src/Block.php
+++ b/src/Block.php
@@ -732,18 +732,21 @@ abstract class Block extends Composer implements BlockContract
      */
     public function toJson(): string
     {
+        $acf = Collection::make([
+            'blockVersion' => $this->getBlockVersion(),
+            'mode' => $this->mode,
+            'postTypes' => $this->post_types,
+            'renderTemplate' => $this::class,
+            'usePostMeta' => $this->usePostMeta,
+            'validate' => $this->validate,
+        ])->when($this->getBlockVersion() >= 3, function (Collection $acf) {
+            return $acf->put('autoInlineEditing', $this->autoInlineEditing ?? false);
+        });
+
         $settings = $this->settings()
             ->put('name', $this->namespace)
             ->put('apiVersion', $this->getApiVersion())
-            ->put('acf', [
-                'blockVersion' => $this->getBlockVersion(),
-                'mode' => $this->mode,
-                'postTypes' => $this->post_types,
-                'renderTemplate' => $this::class,
-                'usePostMeta' => $this->usePostMeta,
-                'validate' => $this->validate,
-                'autoInlineEditing' => $this->autoInlineEditing,
-            ])
+            ->put('acf', $acf)
             ->forget([
                 'api_version',
                 'acf_block_version',

--- a/src/Block.php
+++ b/src/Block.php
@@ -292,6 +292,13 @@ abstract class Block extends Composer implements BlockContract
     public $validate = true;
 
     /**
+     * Enable inline editing for block fields (ACF Pro 6.7+).
+     *
+     * @var bool|null
+     */
+    public $autoInlineEditing = null;
+
+    /**
      * The block attributes.
      */
     public function attributes(): array
@@ -727,6 +734,7 @@ abstract class Block extends Composer implements BlockContract
                 'renderTemplate' => $this::class,
                 'usePostMeta' => $this->usePostMeta,
                 'validate' => $this->validate,
+                'autoInlineEditing' => $this->autoInlineEditing,
             ])
             ->forget([
                 'api_version',

--- a/src/Block.php
+++ b/src/Block.php
@@ -280,9 +280,9 @@ abstract class Block extends Composer implements BlockContract
     /**
      * The internal ACF block version.
      *
-     * @var int
+     * @var int|null
      */
-    public $blockVersion = 2;
+    public $blockVersion;
 
     /**
      * Validate block fields as per the field group configuration.
@@ -529,6 +529,14 @@ abstract class Block extends Composer implements BlockContract
     }
 
     /**
+     * Retrieve the block version.
+     */
+    public function getBlockVersion(): int
+    {
+        return $this->blockVersion ?? 2;
+    }
+
+    /**
      * Retrieve the block text domain.
      */
     public function getTextDomain(): string
@@ -671,7 +679,7 @@ abstract class Block extends Composer implements BlockContract
             'styles' => $this->getStyles(),
             'supports' => $this->getSupports(),
             'textdomain' => $this->getTextDomain(),
-            'acf_block_version' => $this->blockVersion,
+            'acf_block_version' => $this->getBlockVersion(),
             'api_version' => $this->getApiVersion(),
             'validate' => $this->validate,
             'use_post_meta' => $this->usePostMeta,
@@ -728,7 +736,7 @@ abstract class Block extends Composer implements BlockContract
             ->put('name', $this->namespace)
             ->put('apiVersion', $this->getApiVersion())
             ->put('acf', [
-                'blockVersion' => $this->blockVersion,
+                'blockVersion' => $this->getBlockVersion(),
                 'mode' => $this->mode,
                 'postTypes' => $this->post_types,
                 'renderTemplate' => $this::class,


### PR DESCRIPTION
With the release of [ACF (Pro) 6.7](https://www.advancedcustomfields.com/blog/acf-6-7-released/), inline editing is now supported. To enable this feature for blocks, you need to [add `“autoInlineEditing“: true` to the block.json](https://www.advancedcustomfields.com/blog/acf-6-7-released/#how-to-enable-inline-editing) file.

This PR introduces a new configuration option to enable or disable inline editing.

Furthermore, we couldn’t explicitly set the `blockVersion` through configuration. This issue has been resolved as well.