### PR TITLE
🩹 Fix block rendering compatibility with SCF

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -627,6 +627,16 @@ abstract class Block extends Composer implements BlockContract
             $block['attributes'] ?? []
         );
 
+        // Store render_template (class name) instead of render_callback (closure)
+        // in the ACF block-types store. This ensures compatibility with both ACF Pro
+        // and SCF: SCF reads render_callback from the store and would call the closure
+        // directly, bypassing the acf_block_render_template action that acf-composer
+        // listens on. By setting render_callback to false and render_template to the
+        // block class name, SCF falls through to the render_template path and fires
+        // the action. ACF Pro ignores the store values, so this is backwards-compatible.
+        $block['render_callback'] = false;
+        $block['render_template'] = static::class;
+
         acf_get_store('block-types')->set($block['name'], $block);
 
         $block['render_callback'] = 'acf_render_block_callback';


### PR DESCRIPTION
## Summary
- SCF reads `render_callback` from its internal block-types store, while ACF Pro reads it from the WordPress block registry
- Since acf-composer stores a closure as `render_callback`, SCF calls it directly — bypassing the `acf_block_render_template` action that acf-composer listens on
- This sets `render_callback` to `false` and `render_template` to the block class name in the ACF store, so SCF falls through to the `render_template` path and fires the action

## Why
[Secure Custom Fields (SCF)](https://wordpress.org/plugins/secure-custom-fields/) is the community fork of ACF after WP Engine acquired it. Projects migrating from ACF Pro to SCF find that custom blocks registered via acf-composer don't render — the editor shows an infinite spinner or a memory exhaustion error.

## Backwards compatibility
ACF Pro ignores the store values and always uses the `render_callback` passed to `register_block_type()` (which remains `acf_render_block_callback`). This change is fully backwards-compatible.

## Test plan
- [x] Verify blocks render correctly in the editor with ACF Pro
- [x] Verify blocks render correctly in the editor with SCF
- [x] Verify blocks render correctly on the frontend with both

🤖 Generated with [Claude Code](https://claude.com/claude-code)